### PR TITLE
feat: dino turns to ask question, says yaaaaay/beeeep on answer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -137,6 +137,13 @@ main {
 .dino-celebrate { animation: dino-celebrate 0.8s ease-in-out 2 !important; }
 .dino-shake     { animation: dino-shake     0.6s ease-in-out !important; }
 .dino-talk      { animation: dino-talk      0.3s ease-in-out infinite !important; }
+.dino-ask       { animation: dino-ask       3s ease-in-out infinite !important; }
+
+@keyframes dino-ask {
+  0%, 100% { transform: scaleX(-1) translateY(0) rotate(0deg); }
+  30%       { transform: scaleX(-1) translateY(-8px) rotate(-1deg); }
+  70%       { transform: scaleX(-1) translateY(-4px) rotate(1deg); }
+}
 
 /* ── Speech bubble ─────────────────────────────────── */
 .speech-bubble {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -233,6 +233,16 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// Play a short reaction sound ("yaaaaay" / "beeeep") with lip-sync
+function playReaction(text) {
+  const teeth = els.dinoTeeth;
+  teeth.style.display = 'block';
+  animateMouth(true);
+  const done = () => { animateMouth(false); teeth.style.display = 'none'; };
+  playAudioUrl(`/api/tts?text=${encodeURIComponent(text)}&language=english`)
+    .then(done).catch(done);
+}
+
 // Schedule a transition (next word, retry, etc.). IDs stored so Stop can cancel them.
 function scheduleTransition(fn, delayMs) {
   const id = setTimeout(() => {
@@ -406,7 +416,7 @@ function handleResult(result) {
     els.wordCard.classList.add('correct-flash');
     launchConfetti();
     setBubble(randomMsg('correct'));
-    playAudioUrl(`/api/tts?text=${encodeURIComponent('yaaaaay')}&language=english`).catch(() => {});
+    playReaction('yaaaaay');
 
     // Move to next word after a short delay (cancelled if Stop pressed)
     scheduleTransition(nextWord, 2200);
@@ -424,7 +434,7 @@ function handleResult(result) {
     animateDino('shake');
     els.wordCard.classList.add('wrong-flash');
     setBubble("Good try! Let's move on. 🌟");
-    playAudioUrl(`/api/tts?text=${encodeURIComponent('beeeep')}&language=english`).catch(() => {});
+    playReaction('beeeep');
 
     scheduleTransition(nextWord, 3000);
 
@@ -438,7 +448,7 @@ function handleResult(result) {
     animateDino('shake');
     els.wordCard.classList.add('wrong-flash');
     setBubble(randomMsg('wrong'));
-    playAudioUrl(`/api/tts?text=${encodeURIComponent('beeeep')}&language=english`).catch(() => {});
+    playReaction('beeeep');
 
     // Say "Myra, repeat after me! <word>" again, then start recording (cancelled if Stop pressed)
     scheduleTransition(() => {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -192,7 +192,7 @@ async function playPromptThenRecord() {
   const { translation, language } = state.currentWord;
 
   setBubble(`${childName}, repeat after me! 🎤`);
-  animateDino('talk');
+  animateDino('ask');
 
   try {
     // 1. Play "<Name>, repeat after me!" in English
@@ -406,6 +406,7 @@ function handleResult(result) {
     els.wordCard.classList.add('correct-flash');
     launchConfetti();
     setBubble(randomMsg('correct'));
+    playAudioUrl(`/api/tts?text=${encodeURIComponent('yaaaaay')}&language=english`).catch(() => {});
 
     // Move to next word after a short delay (cancelled if Stop pressed)
     scheduleTransition(nextWord, 2200);
@@ -423,6 +424,7 @@ function handleResult(result) {
     animateDino('shake');
     els.wordCard.classList.add('wrong-flash');
     setBubble("Good try! Let's move on. 🌟");
+    playAudioUrl(`/api/tts?text=${encodeURIComponent('beeeep')}&language=english`).catch(() => {});
 
     scheduleTransition(nextWord, 3000);
 
@@ -436,6 +438,7 @@ function handleResult(result) {
     animateDino('shake');
     els.wordCard.classList.add('wrong-flash');
     setBubble(randomMsg('wrong'));
+    playAudioUrl(`/api/tts?text=${encodeURIComponent('beeeep')}&language=english`).catch(() => {});
 
     // Say "Myra, repeat after me! <word>" again, then start recording (cancelled if Stop pressed)
     scheduleTransition(() => {
@@ -512,7 +515,7 @@ function updateDots(index, correct) {
 // ── Dino animations ───────────────────────────────────
 function animateDino(state_name) {
   const svg = els.dinoSvg;
-  svg.classList.remove('dino-celebrate', 'dino-shake', 'dino-talk');
+  svg.classList.remove('dino-celebrate', 'dino-shake', 'dino-talk', 'dino-ask');
 
   const teeth = els.dinoTeeth;
 
@@ -522,6 +525,11 @@ function animateDino(state_name) {
     setTimeout(() => { teeth.style.display = 'none'; }, 1600);
   } else if (state_name === 'shake') {
     svg.classList.add('dino-shake');
+  } else if (state_name === 'ask') {
+    // Dino turns to face the toddler and asks the question
+    svg.classList.add('dino-ask');
+    teeth.style.display = 'block';
+    animateMouth(true);
   } else if (state_name === 'talk') {
     svg.classList.add('dino-talk');
     teeth.style.display = 'block';


### PR DESCRIPTION
- Add `dino-ask` CSS keyframe animation: mirrors the dino horizontally
  (scaleX(-1)) so it turns to face the toddler while keeping the gentle
  idle bobbing motion
- Add 'ask' state to animateDino(): applies dino-ask class, opens mouth
  with lip-sync animation, and shows teeth - just like 'talk' but facing
  the other way toward the child
- Switch playPromptThenRecord() from animateDino('talk') to
  animateDino('ask') so the dino visibly turns toward the toddler when
  it says "repeat after me!"
- Play TTS "yaaaaay" (English) immediately on a correct answer alongside
  the celebrate animation
- Play TTS "beeeep" (English) immediately on a wrong answer (both the
  retryable and out-of-attempts cases) alongside the shake animation

https://claude.ai/code/session_01MeqKCs6hfdU9Hu8sdU6x5a