### PR TITLE
feat(infra): add $20/day cost guardrail with auto-restore

### DIFF
--- a/infra/apis.tf
+++ b/infra/apis.tf
@@ -63,3 +63,8 @@ resource "google_project_service" "eventarc" {
   service            = "eventarc.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_service" "monitoring" {
+  service            = "monitoring.googleapis.com"
+  disable_on_destroy = false
+}

--- a/infra/budgets.tf
+++ b/infra/budgets.tf
@@ -96,6 +96,246 @@ resource "google_project_iam_member" "kill_run_logs" {
   member  = "serviceAccount:${google_service_account.kill_run.email}"
 }
 
+# ── Project data (needed for Cloud Monitoring service-agent IAM) ───────────────
+data "google_project" "project" {
+  project_id = var.project_id
+  depends_on = [google_project_service.cloudresourcemanager]
+}
+
+# ── Daily cost guardrail: $20/day via Cloud Monitoring ────────────────────────
+# GCP billing budgets only support MONTH/QUARTER/YEAR periods. The daily guardrail
+# is implemented via a Cloud Monitoring alerting policy that computes the 24-hour
+# delta of billing/monthly_cost and fires when it exceeds var.daily_budget_limit.
+
+resource "google_pubsub_topic" "daily_alerts" {
+  name = "dino-app-daily-alerts"
+}
+
+# Cloud Monitoring service agent must be able to publish to the topic
+resource "google_pubsub_topic_iam_member" "monitoring_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.daily_alerts.name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-monitoring-notification.iam.gserviceaccount.com"
+}
+
+resource "google_monitoring_notification_channel" "daily_pubsub" {
+  display_name = "Daily Cost Alert → Pub/Sub"
+  type         = "pubsub"
+
+  labels = {
+    topic = google_pubsub_topic.daily_alerts.id
+  }
+
+  depends_on = [
+    google_project_service.monitoring,
+    google_pubsub_topic_iam_member.monitoring_publisher,
+  ]
+}
+
+# Alert fires when 24-hour billing cost delta > daily_budget_limit ($20 default)
+resource "google_monitoring_alert_policy" "daily_cost" {
+  display_name = "dino-app-daily-cost-guardrail"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Daily billing spend > $${var.daily_budget_limit}"
+
+    condition_threshold {
+      filter = "metric.type=\"billing.googleapis.com/billing/monthly_cost\" resource.type=\"global\""
+
+      aggregations {
+        alignment_period     = "86400s"        # 24-hour window
+        per_series_aligner   = "ALIGN_DELTA"   # cost increase over the window = daily spend
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = []
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.daily_budget_limit
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.daily_pubsub.name]
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "86400s"   # at most one kill notification per day
+    }
+    auto_close = "86400s" # auto-resolve after 24h (metric resets with new day)
+  }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+# Daily guardrail Cloud Function — kills Cloud Run when daily limit is breached
+data "archive_file" "daily_guardrail" {
+  type        = "zip"
+  output_path = "${path.module}/lambda/daily_guardrail.zip"
+  source {
+    content  = file("${path.module}/lambda/daily_guardrail.py")
+    filename = "main.py"
+  }
+  source {
+    content  = file("${path.module}/lambda/requirements.txt")
+    filename = "requirements.txt"
+  }
+}
+
+resource "google_storage_bucket_object" "daily_guardrail" {
+  name   = "daily_guardrail_${data.archive_file.daily_guardrail.output_md5}.zip"
+  bucket = google_storage_bucket.functions.name
+  source = data.archive_file.daily_guardrail.output_path
+}
+
+resource "google_cloudfunctions2_function" "daily_guardrail" {
+  name     = "dino-app-daily-guardrail"
+  location = var.region
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.daily_guardrail.name
+      }
+    }
+  }
+
+  service_config {
+    min_instance_count    = 0
+    max_instance_count    = 1
+    available_memory      = "256M"
+    timeout_seconds       = 30
+    service_account_email = google_service_account.kill_run.email   # reuse existing SA
+
+    environment_variables = {
+      CLOUD_RUN_SERVICE = google_cloud_run_v2_service.app.name
+      CLOUD_RUN_REGION  = var.region
+      GCP_PROJECT       = var.project_id
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic   = google_pubsub_topic.daily_alerts.id
+    retry_policy   = "RETRY_POLICY_RETRY"
+  }
+
+  depends_on = [
+    google_project_service.eventarc,
+    google_project_service.cloudfunctions,
+  ]
+}
+
+# ── Daily midnight restore ─────────────────────────────────────────────────────
+# Cloud Scheduler fires at midnight UTC each day → restore_run re-enables Cloud Run.
+# This resets the service after the daily billing window closes, so Myra can use
+# the app again the next day even if it was killed by the guardrail.
+
+resource "google_pubsub_topic" "restore_trigger" {
+  name = "dino-app-restore-trigger"
+}
+
+data "archive_file" "restore_run" {
+  type        = "zip"
+  output_path = "${path.module}/lambda/restore_run.zip"
+  source {
+    content  = file("${path.module}/lambda/restore_run.py")
+    filename = "main.py"
+  }
+  source {
+    content  = file("${path.module}/lambda/requirements.txt")
+    filename = "requirements.txt"
+  }
+}
+
+resource "google_storage_bucket_object" "restore_run" {
+  name   = "restore_run_${data.archive_file.restore_run.output_md5}.zip"
+  bucket = google_storage_bucket.functions.name
+  source = data.archive_file.restore_run.output_path
+}
+
+resource "google_service_account" "daily_restore" {
+  account_id   = "dino-app-daily-restore"
+  display_name = "Dino App Daily Restore Function"
+}
+
+resource "google_project_iam_member" "daily_restore_cloud_run" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.daily_restore.email}"
+}
+
+resource "google_project_iam_member" "daily_restore_logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.daily_restore.email}"
+}
+
+resource "google_cloudfunctions2_function" "restore_run" {
+  name     = "dino-app-restore-run"
+  location = var.region
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.restore_run.name
+      }
+    }
+  }
+
+  service_config {
+    min_instance_count    = 0
+    max_instance_count    = 1
+    available_memory      = "256M"
+    timeout_seconds       = 30
+    service_account_email = google_service_account.daily_restore.email
+
+    environment_variables = {
+      CLOUD_RUN_SERVICE = google_cloud_run_v2_service.app.name
+      CLOUD_RUN_REGION  = var.region
+      GCP_PROJECT       = var.project_id
+      MAX_INSTANCES     = tostring(var.max_instances)
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic   = google_pubsub_topic.restore_trigger.id
+    retry_policy   = "RETRY_POLICY_DO_NOT_RETRY"
+  }
+
+  depends_on = [
+    google_project_service.eventarc,
+    google_project_service.cloudfunctions,
+  ]
+}
+
+resource "google_cloud_scheduler_job" "daily_restore" {
+  name             = "dino-app-daily-restore"
+  description      = "Restore Cloud Run at midnight UTC after daily cost window resets"
+  schedule         = "0 0 * * *"
+  time_zone        = "UTC"
+  attempt_deadline = "60s"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.restore_trigger.id
+    data       = base64encode("{\"action\":\"restore\"}")
+  }
+
+  depends_on = [google_project_service.cloudscheduler]
+}
+
 # ── Billing budget ─────────────────────────────────────────────────────────────
 resource "google_billing_budget" "monthly" {
   billing_account = var.billing_account_id

--- a/infra/lambda/daily_guardrail.py
+++ b/infra/lambda/daily_guardrail.py
@@ -1,0 +1,42 @@
+"""
+GCP Cloud Function: daily cost guardrail kill-switch.
+Triggered by Cloud Monitoring alert when the 24-hour billing cost delta exceeds $20.
+Only acts on OPEN incidents — ignores resolved/closed notifications.
+"""
+import os
+import json
+import base64
+import functions_framework
+from google.cloud import run_v2
+
+
+@functions_framework.cloud_event
+def handler(cloud_event):
+    data = base64.b64decode(cloud_event.data["message"]["data"]).decode("utf-8")
+    notification = json.loads(data)
+
+    # Cloud Monitoring sends both "open" (firing) and "closed" (resolved) notifications.
+    # Only kill Cloud Run when the alert fires (state="open").
+    incident = notification.get("incident", {})
+    state = incident.get("state", "")
+
+    if state != "open":
+        print(f"Alert state is '{state}' — no action taken.")
+        return
+
+    summary = incident.get("summary", "daily cost limit triggered")
+    print(f"Daily cost guardrail OPEN: {summary}")
+
+    project = os.environ["GCP_PROJECT"]
+    region = os.environ["CLOUD_RUN_REGION"]
+    service_name = os.environ["CLOUD_RUN_SERVICE"]
+
+    client = run_v2.ServicesClient()
+    service_path = f"projects/{project}/locations/{region}/services/{service_name}"
+
+    service = client.get_service(name=service_path)
+    service.template.scaling.max_instance_count = 0
+    service.template.scaling.min_instance_count = 0
+
+    client.update_service(service=service)
+    print(f"Scaled {service_name} to 0 instances — daily $20 limit breached.")

--- a/infra/lambda/restore_run.py
+++ b/infra/lambda/restore_run.py
@@ -1,0 +1,29 @@
+"""
+GCP Cloud Function: daily restore.
+Triggered by Cloud Scheduler at midnight UTC every day.
+Restores Cloud Run max instances so the service is available at the start of each new billing day.
+"""
+import os
+import functions_framework
+from google.cloud import run_v2
+
+
+@functions_framework.cloud_event
+def handler(cloud_event):
+    max_instances = int(os.environ.get("MAX_INSTANCES", "2"))
+    project = os.environ["GCP_PROJECT"]
+    region = os.environ["CLOUD_RUN_REGION"]
+    service_name = os.environ["CLOUD_RUN_SERVICE"]
+
+    client = run_v2.ServicesClient()
+    service_path = f"projects/{project}/locations/{region}/services/{service_name}"
+
+    service = client.get_service(name=service_path)
+
+    if service.template.scaling.max_instance_count == 0:
+        service.template.scaling.max_instance_count = max_instances
+        service.template.scaling.min_instance_count = 0
+        client.update_service(service=service)
+        print(f"Restored {service_name} to {max_instances} max instances for new day.")
+    else:
+        print(f"{service_name} already running at {service.template.scaling.max_instance_count} max instances — no restore needed.")

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -44,6 +44,12 @@ variable "budget_limit" {
   default     = 50
 }
 
+variable "daily_budget_limit" {
+  description = "Daily spend limit in USD - kill-switch fires when 24-hour cost delta exceeds this"
+  type        = number
+  default     = 20
+}
+
 variable "domain" {
   description = "Custom domain name (e.g. myra-language-teacher.ai) — leave empty to use nip.io fallback"
   type        = string


### PR DESCRIPTION
GCP billing budgets only support MONTH/QUARTER/YEAR periods, so the
daily guardrail is implemented via Cloud Monitoring:

- Alerting policy monitors billing/monthly_cost with ALIGN_DELTA over
  a 24-hour window; fires when daily spend exceeds var.daily_budget_limit
  ($20 default)
- Cloud Monitoring → Pub/Sub (dino-app-daily-alerts) → daily_guardrail
  Cloud Function scales Cloud Run to 0 when the alert opens
- daily_guardrail only acts on state="open" incidents, ignoring resolved
  notifications to avoid double-triggering
- Cloud Scheduler (0 0 * * * UTC) → restore_run Cloud Function restores
  Cloud Run max_instances at midnight so the app is available each new day
- Also adds missing data.google_project.project data source (was referenced
  in budgets.tf but never defined — would have caused plan failures)
- Adds monitoring.googleapis.com API enablement to apis.tf
- Adds daily_budget_limit variable (default: 20)

https://claude.ai/code/session_01Q8TfZ7efsZaQ2wFSwKHnwy