### PR TITLE
feat(stt): replace openai-whisper with faster-whisper (CTranslate2 backend)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ COPY main.py words_db.py speech_service.py tts_service.py ./
 COPY templates/ templates/
 COPY static/ static/
 
-# Pre-download Whisper tiny model (~39 MB) so first request isn't slow
-# Model saved to /root/.cache/whisper/tiny.pt inside the image
-RUN python -c "import whisper; whisper.load_model('tiny'); print('Whisper tiny model cached.')"
+# Pre-download faster-whisper tiny model (~39 MB CTranslate2 format) so first request isn't slow
+# Model saved to /root/.cache/huggingface/hub/ inside the image
+RUN python -c "from faster_whisper import WhisperModel; WhisperModel('tiny', device='cpu', compute_type='int8'); print('faster-whisper tiny model cached.')"
 
 EXPOSE 8000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.0
 uvicorn[standard]==0.32.0
 python-multipart==0.0.12
 jinja2==3.1.4
-openai-whisper==20250625
+faster-whisper>=1.1.0
 gTTS==2.5.3
 pydub==0.25.1
 python-dotenv==1.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,15 @@ import pytest
 from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
-# Provide a lightweight whisper stub in sys.modules so that
+# Provide a lightweight faster_whisper stub in sys.modules so that
 #   import speech_service
-# works even when openai-whisper is NOT installed (e.g. lightweight CI image).
-# The real whisper import happens lazily inside get_whisper_model(); tests that
-# exercise that path patch sys.modules['whisper'] themselves.
+# works even when faster-whisper is NOT installed (e.g. lightweight CI image).
+# The real faster_whisper import happens lazily inside get_whisper_model(); tests
+# that exercise that path patch sys.modules['faster_whisper'] themselves.
 # ---------------------------------------------------------------------------
-if "whisper" not in sys.modules:
-    _whisper_stub = MagicMock()
-    sys.modules["whisper"] = _whisper_stub
+if "faster_whisper" not in sys.modules:
+    _faster_whisper_stub = MagicMock()
+    sys.modules["faster_whisper"] = _faster_whisper_stub
 
 # ---------------------------------------------------------------------------
 # noisereduce is optional; stub it out so importing speech_service never fails


### PR DESCRIPTION
Switches speech_service.py from openai-whisper to faster-whisper, giving
~4× CPU speedup with int8 quantization baked in via CTranslate2.

API changes:
- WhisperModel(size, device="cpu", compute_type="int8") replaces whisper.load_model()
- model.transcribe() now returns (segments_generator, info); joined with " ".join()
- fp16=False removed (compute_type at load time supersedes it)
- New _whisper_compute_type = "int8" module var (configurable: float16 for GPU)

Test + infra updates required by the library swap:
- conftest.py: stub faster_whisper instead of whisper
- TestGetWhisperModel: patch faster_whisper.WhisperModel instead of whisper.load_model
- _make_model_mock: return (segments_list, info) tuples matching faster-whisper API
- Dockerfile: pre-download via WhisperModel() instead of whisper.load_model()

All 197 tests pass.

https://claude.ai/code/session_01CDLGwqvMhmLsR5VKQSD27m