### PR TITLE
feat(logging): add structured per-step timing logs for Cloud Run profiling

### DIFF
--- a/tts_service.py
+++ b/tts_service.py
@@ -1,6 +1,7 @@
 import io
 import asyncio
 import logging
+import time
 from functools import lru_cache
 from gtts import gTTS
 
@@ -26,17 +27,27 @@ async def generate_tts(text: str, language: str, slow: bool = True) -> bytes:
     """Generate TTS audio bytes for the given text in the specified language."""
     lang_code = LANGUAGE_CODES.get(language, "en")
     loop = asyncio.get_event_loop()
+    t0 = time.perf_counter()
     try:
         audio_bytes = await loop.run_in_executor(
             None, _generate_tts_sync, text, lang_code, slow
+        )
+        logger.info(
+            f"[TIMING] step=tts_generate lang={language} text_len={len(text)} "
+            f"audio_bytes={len(audio_bytes)} duration_ms={1000*(time.perf_counter()-t0):.1f}"
         )
         return audio_bytes
     except Exception as e:
         logger.error(f"TTS generation failed for '{text}' in {language}: {e}")
         # Fall back to English if target language fails
         try:
+            t1 = time.perf_counter()
             audio_bytes = await loop.run_in_executor(
                 None, _generate_tts_sync, text, "en", slow
+            )
+            logger.info(
+                f"[TIMING] step=tts_fallback lang=en text_len={len(text)} "
+                f"audio_bytes={len(audio_bytes)} duration_ms={1000*(time.perf_counter()-t1):.1f}"
             )
             return audio_bytes
         except Exception as e2:


### PR DESCRIPTION
Instrument every significant processing stage with [TIMING] prefixed log
lines (key=value pairs) so Cloud Run logs expose exactly where latency
is spent without touching business logic or test contracts.

Stages logged (all emit duration_ms):
  speech_service:
    - whisper_model_load   (cold-start only; includes cold_start=true flag)
    - audio_decode         (pydub/ffmpeg format detection)
    - audio_resample       (16 kHz mono conversion)
    - noise_reduction      (when NOISE_REDUCTION_ENABLED=True)
    - wav_export           (write normalised WAV to temp file)
    - total_audio_convert  (full _convert_to_wav wall time)
    - convert_to_wav       (async executor boundary in recognize_speech)
    - whisper_model_ready  (warm-model check latency)
    - whisper_pass1        (native-language transcription)
    - whisper_pass2        (romanised/phonetic transcription)
    - total_transcribe     (both Whisper passes combined)
    - total_recognize      (full recognize_speech wall time + correct/sim)
  tts_service:
    - tts_generate         (gTTS network round-trip + encode)
    - tts_fallback         (English fallback, when triggered)
  main:
    - audio_upload_read    (multipart body read)
    - api_tts              (full /api/tts endpoint)
    - api_recognize        (full /api/recognize endpoint)

Filter in Cloud Run with: textPayload:"[TIMING]"
All 197 existing tests pass unchanged.

https://claude.ai/code/session_01FWHgNUCsNrCpQYmZ4iosn9