### PR TITLE
feat(metrics): add log collector script and standalone comparison dashboard

### DIFF
--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Collect [TIMING] metrics from a local log file or GCP Cloud Logging.
+
+Usage
+-----
+  # Capture local logs while running the app
+  python main.py 2>&1 | tee local.log
+  python tools/collect_metrics.py --source local --input local.log --output local_metrics.json
+
+  # Pull last 24 h of GCP Cloud Run logs
+  python tools/collect_metrics.py --source gcp --project my-project --output gcp_metrics.json
+
+  # Override environment label
+  python tools/collect_metrics.py --source local --input local.log --output local_metrics.json --env laptop
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+
+# Matches the [TIMING] prefix anywhere in a log line
+_TIMING_RE = re.compile(r"\[TIMING\]\s+(.+)")
+# Handles both  key='quoted value'  and  key=unquoted
+_KV_RE = re.compile(r"(\w+)='([^']*)'|(\w+)=([^\s']+)")
+
+_NUMERIC_KEYS = {"duration_ms", "size_bytes", "text_len", "audio_bytes", "audio_duration_ms", "best_sim"}
+_BOOL_KEYS = {"correct", "cold_start", "is_correct"}
+
+
+def _parse_kv(kv_str: str) -> dict:
+    result = {}
+    for m in _KV_RE.finditer(kv_str):
+        if m.group(1):  # quoted
+            key, val = m.group(1), m.group(2)
+        else:           # unquoted
+            key, val = m.group(3), m.group(4)
+
+        # Type coercion
+        if key in _NUMERIC_KEYS:
+            try:
+                result[key] = float(val)
+            except ValueError:
+                result[key] = val
+        elif key in _BOOL_KEYS:
+            result[key] = val.lower() in ("true", "1", "yes")
+        else:
+            result[key] = val
+    return result
+
+
+def _parse_timing_line(line: str, timestamp: str | None = None) -> dict | None:
+    m = _TIMING_RE.search(line)
+    if not m:
+        return None
+    sample = _parse_kv(m.group(1))
+    if not sample.get("step"):
+        return None
+    if timestamp:
+        sample["timestamp"] = timestamp
+    return sample
+
+
+def _extract_timestamp_from_line(line: str) -> str | None:
+    """Try to grab an ISO/logging timestamp from a local log line."""
+    # Python logger default: '2024-01-15 12:00:00,123'
+    m = re.search(r"(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})", line)
+    return m.group(1).replace(" ", "T") + "Z" if m else None
+
+
+# ---------------------------------------------------------------------------
+# Local log file
+# ---------------------------------------------------------------------------
+
+def parse_local_log(filepath: str) -> list[dict]:
+    samples = []
+    with open(filepath, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            ts = _extract_timestamp_from_line(line)
+            sample = _parse_timing_line(line, timestamp=ts)
+            if sample:
+                samples.append(sample)
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# GCP Cloud Logging
+# ---------------------------------------------------------------------------
+
+def parse_gcp_logs(project: str, service: str, hours: int) -> list[dict]:
+    since = (
+        datetime.now(timezone.utc) - timedelta(hours=hours)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    log_filter = (
+        f'resource.type="cloud_run_revision" '
+        f'resource.labels.service_name="{service}" '
+        f'(textPayload=~"\\[TIMING\\]" OR jsonPayload.message=~"\\[TIMING\\]") '
+        f'timestamp>="{since}"'
+    )
+
+    cmd = [
+        "gcloud", "logging", "read", log_filter,
+        "--project", project,
+        "--format", "json",
+        "--limit", "2000",
+    ]
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"gcloud error:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        entries = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse gcloud output as JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    samples = []
+    for entry in entries:
+        timestamp = entry.get("timestamp", "")
+        # Cloud Run may log as textPayload or jsonPayload.message
+        text = entry.get("textPayload") or entry.get("jsonPayload", {}).get("message", "")
+        sample = _parse_timing_line(text, timestamp=timestamp)
+        if sample:
+            samples.append(sample)
+
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collect [TIMING] metrics into a JSON file for the dashboard."
+    )
+    parser.add_argument("--source", choices=["local", "gcp"], required=True,
+                        help="Where to read logs from.")
+    parser.add_argument("--input", metavar="FILE",
+                        help="Local log file (required when --source local).")
+    parser.add_argument("--project", metavar="PROJECT_ID",
+                        help="GCP project ID (required when --source gcp).")
+    parser.add_argument("--service", default="dino-app",
+                        help="Cloud Run service name (default: dino-app).")
+    parser.add_argument("--hours", type=int, default=24,
+                        help="Hours of history to pull from GCP (default: 24).")
+    parser.add_argument("--output", required=True, metavar="FILE",
+                        help="Output JSON path.")
+    parser.add_argument("--env", default=None,
+                        help="Environment label (default: 'local' or 'gcp').")
+    args = parser.parse_args()
+
+    if args.source == "local":
+        if not args.input:
+            parser.error("--input is required when --source local")
+        samples = parse_local_log(args.input)
+        env_label = args.env or "local"
+    else:
+        if not args.project:
+            parser.error("--project is required when --source gcp")
+        samples = parse_gcp_logs(args.project, args.service, args.hours)
+        env_label = args.env or "gcp"
+
+    output = {
+        "env": env_label,
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "sample_count": len(samples),
+        "samples": samples,
+    }
+
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(output, fh, indent=2)
+
+    print(f"✓ Collected {len(samples)} timing samples → {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dashboard.html
+++ b/tools/dashboard.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Myra — Performance Metrics Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      background: #0f1117;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; letter-spacing: -0.02em; }
+    h2 { font-size: 1rem; font-weight: 600; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 12px; }
+    h3 { font-size: 0.85rem; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; }
+
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 28px;
+      border-bottom: 1px solid #1e293b;
+      padding-bottom: 20px;
+    }
+    .header .subtitle { font-size: 0.85rem; color: #64748b; margin-top: 2px; }
+
+    /* ── File loaders ── */
+    .loaders {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-bottom: 28px;
+    }
+    .loader-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 18px 20px;
+      transition: border-color 0.2s;
+    }
+    .loader-card.loaded { border-color: #22d3ee; }
+    .loader-card label { display: block; font-size: 0.8rem; color: #94a3b8; margin-bottom: 8px; }
+    .loader-card input[type=file] { width: 100%; font-size: 0.8rem; color: #e2e8f0; }
+    .loader-card input[type=file]::file-selector-button {
+      background: #334155; border: none; color: #e2e8f0; padding: 5px 12px;
+      border-radius: 5px; cursor: pointer; font-size: 0.78rem; margin-right: 10px;
+    }
+    .loader-card input[type=file]::file-selector-button:hover { background: #475569; }
+    .env-badge {
+      display: inline-block; margin-top: 10px;
+      padding: 3px 10px; border-radius: 20px; font-size: 0.72rem; font-weight: 600;
+    }
+    .badge-local  { background: #14532d; color: #4ade80; }
+    .badge-gcp    { background: #1e3a5f; color: #60a5fa; }
+    .badge-custom { background: #3b1e6e; color: #c084fc; }
+    .meta-text { font-size: 0.72rem; color: #64748b; margin-top: 4px; }
+
+    /* ── Stat cards ── */
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      gap: 12px;
+      margin-bottom: 28px;
+    }
+    .stat-card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 14px 16px;
+    }
+    .stat-label { font-size: 0.72rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+    .stat-values { display: flex; gap: 14px; align-items: baseline; }
+    .stat-val { font-size: 1.25rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+    .stat-val.local  { color: #4ade80; }
+    .stat-val.gcp    { color: #60a5fa; }
+    .stat-val.custom { color: #c084fc; }
+    .stat-unit { font-size: 0.7rem; color: #64748b; }
+
+    /* ── Sections ── */
+    .section { margin-bottom: 32px; }
+    .chart-wrap {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 10px;
+      padding: 20px;
+      position: relative;
+    }
+    .chart-wrap canvas { max-height: 320px; }
+
+    /* ── Legend ── */
+    .legend {
+      display: flex; gap: 18px; margin-bottom: 14px;
+      font-size: 0.78rem; color: #94a3b8;
+    }
+    .legend-dot {
+      display: inline-block; width: 10px; height: 10px;
+      border-radius: 50%; margin-right: 5px; vertical-align: middle;
+    }
+    .dot-local  { background: #4ade80; }
+    .dot-gcp    { background: #60a5fa; }
+    .dot-custom { background: #c084fc; }
+
+    /* ── Raw table ── */
+    .table-wrap { overflow-x: auto; }
+    table {
+      width: 100%; border-collapse: collapse;
+      font-size: 0.78rem; font-variant-numeric: tabular-nums;
+    }
+    thead tr { background: #0f172a; }
+    th, td { padding: 7px 12px; border-bottom: 1px solid #1e293b; white-space: nowrap; }
+    th { color: #64748b; text-align: left; font-weight: 600; }
+    td.step { color: #e2e8f0; font-weight: 500; }
+    td.env-local  { color: #4ade80; }
+    td.env-gcp    { color: #60a5fa; }
+    td.env-custom { color: #c084fc; }
+    tr:hover td { background: #1e293b; }
+
+    /* ── Empty / hint states ── */
+    .hint {
+      text-align: center; padding: 48px 0;
+      color: #475569; font-size: 0.9rem; line-height: 2;
+    }
+    .hint code { font-size: 0.78rem; background: #1e293b; padding: 2px 6px; border-radius: 4px; color: #94a3b8; }
+
+    .filter-row {
+      display: flex; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; align-items: center;
+      font-size: 0.8rem;
+    }
+    .filter-row label { color: #94a3b8; }
+    .filter-row select {
+      background: #1e293b; border: 1px solid #334155; color: #e2e8f0;
+      padding: 4px 8px; border-radius: 5px; font-size: 0.78rem;
+    }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div>
+    <h1>🦕 Performance Metrics Dashboard</h1>
+    <div class="subtitle">Compare timings across local and GCP Cloud Run — load up to two JSON exports</div>
+  </div>
+</div>
+
+<!-- File loaders -->
+<div class="loaders">
+  <div class="loader-card" id="card-a">
+    <label>Environment A (e.g. local)</label>
+    <input type="file" id="file-a" accept=".json" />
+    <div id="meta-a"></div>
+  </div>
+  <div class="loader-card" id="card-b">
+    <label>Environment B (e.g. GCP)</label>
+    <input type="file" id="file-b" accept=".json" />
+    <div id="meta-b"></div>
+  </div>
+</div>
+
+<!-- Empty hint -->
+<div class="hint" id="hint">
+  Load one or two <code>*_metrics.json</code> files produced by <code>tools/collect_metrics.py</code> to see charts here.<br>
+  <code>python main.py 2>&1 | tee local.log</code><br>
+  <code>python tools/collect_metrics.py --source local --input local.log --output local_metrics.json</code>
+</div>
+
+<!-- Dashboard (hidden until data loaded) -->
+<div id="dashboard" style="display:none">
+
+  <!-- Summary stats -->
+  <div class="section">
+    <h2>Key Metrics</h2>
+    <div class="stats-grid" id="stats-grid"></div>
+  </div>
+
+  <!-- Median chart -->
+  <div class="section">
+    <h2>Median Duration per Step</h2>
+    <div class="chart-wrap">
+      <div class="legend" id="legend-median"></div>
+      <canvas id="chart-median"></canvas>
+    </div>
+  </div>
+
+  <!-- p95 chart -->
+  <div class="section">
+    <h2>p95 Duration per Step</h2>
+    <div class="chart-wrap">
+      <div class="legend" id="legend-p95"></div>
+      <canvas id="chart-p95"></canvas>
+    </div>
+  </div>
+
+  <!-- Raw samples table -->
+  <div class="section">
+    <h2>Raw Samples</h2>
+    <div class="filter-row">
+      <label>Step:</label>
+      <select id="filter-step"><option value="">All</option></select>
+      <label>Env:</label>
+      <select id="filter-env"><option value="">All</option></select>
+    </div>
+    <div class="chart-wrap">
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>env</th><th>step</th><th>duration_ms</th><th>lang</th>
+              <th>correct</th><th>best_sim</th><th>timestamp</th>
+            </tr>
+          </thead>
+          <tbody id="raw-tbody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// ─────────────────────────────────────────────
+// Palette
+// ─────────────────────────────────────────────
+const PALETTE = {
+  local:  { solid: '#4ade80', alpha: 'rgba(74,222,128,0.8)',  dim: 'rgba(74,222,128,0.25)' },
+  gcp:    { solid: '#60a5fa', alpha: 'rgba(96,165,250,0.8)',  dim: 'rgba(96,165,250,0.25)' },
+  custom: { solid: '#c084fc', alpha: 'rgba(192,132,252,0.8)', dim: 'rgba(192,132,252,0.25)' },
+};
+
+function envColor(env) {
+  if (env === 'local')  return PALETTE.local;
+  if (env === 'gcp')    return PALETTE.gcp;
+  return PALETTE.custom;
+}
+function envClass(env) {
+  if (env === 'local') return 'env-local';
+  if (env === 'gcp')   return 'env-gcp';
+  return 'env-custom';
+}
+function badgeClass(env) {
+  if (env === 'local') return 'badge-local';
+  if (env === 'gcp')   return 'badge-gcp';
+  return 'badge-custom';
+}
+
+// ─────────────────────────────────────────────
+// Stats helpers
+// ─────────────────────────────────────────────
+const STEP_ORDER = [
+  'tts_generate', 'api_tts',
+  'audio_upload_read', 'audio_decode', 'audio_resample', 'noise_reduction',
+  'wav_export', 'total_audio_convert', 'convert_to_wav',
+  'whisper_model_load', 'whisper_model_ready',
+  'whisper_pass1', 'whisper_pass2', 'total_transcribe',
+  'total_recognize', 'api_recognize',
+];
+
+const KEY_METRICS = [
+  { key: 'whisper_pass1',      label: 'Whisper Pass 1' },
+  { key: 'whisper_pass2',      label: 'Whisper Pass 2' },
+  { key: 'total_transcribe',   label: 'Total Transcribe' },
+  { key: 'tts_generate',       label: 'TTS Generate' },
+  { key: 'total_audio_convert', label: 'Audio Convert' },
+  { key: 'api_recognize',      label: 'Full Recognize' },
+];
+
+function percentile(arr, p) {
+  if (!arr.length) return null;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+function median(arr) { return percentile(arr, 50); }
+
+function groupByStep(samples) {
+  // returns { stepName: [duration_ms, ...] }
+  const out = {};
+  for (const s of samples) {
+    if (s.duration_ms == null) continue;
+    (out[s.step] = out[s.step] || []).push(s.duration_ms);
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────
+// State
+// ─────────────────────────────────────────────
+let datasets = {}; // { envLabel: { meta, samples } }
+let charts = {};
+
+function allEnvs()     { return Object.keys(datasets); }
+function allSamples()  { return allEnvs().flatMap(e => datasets[e].samples.map(s => ({ ...s, _env: e }))); }
+function allSteps() {
+  const set = new Set(allSamples().map(s => s.step));
+  return STEP_ORDER.filter(s => set.has(s)).concat([...set].filter(s => !STEP_ORDER.includes(s)));
+}
+
+// ─────────────────────────────────────────────
+// Chart.js helpers
+// ─────────────────────────────────────────────
+Chart.defaults.color = '#94a3b8';
+Chart.defaults.borderColor = '#1e293b';
+
+function makeBarChart(canvasId, labels, envDatasets) {
+  const ctx = document.getElementById(canvasId).getContext('2d');
+  if (charts[canvasId]) charts[canvasId].destroy();
+  charts[canvasId] = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: envDatasets.map(({ env, data }) => ({
+        label: env,
+        data,
+        backgroundColor: envColor(env).alpha,
+        borderColor: envColor(env).solid,
+        borderWidth: 1.5,
+        borderRadius: 4,
+      })),
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { ticks: { font: { size: 11 }, maxRotation: 40 }, grid: { color: '#1e293b' } },
+        y: { title: { display: true, text: 'ms', color: '#64748b' }, grid: { color: '#1e293b' } },
+      },
+    },
+  });
+}
+
+// ─────────────────────────────────────────────
+// Render helpers
+// ─────────────────────────────────────────────
+function renderLegend(containerId) {
+  const el = document.getElementById(containerId);
+  el.innerHTML = allEnvs().map(env => {
+    const cls = env === 'local' ? 'dot-local' : env === 'gcp' ? 'dot-gcp' : 'dot-custom';
+    return `<span><span class="legend-dot ${cls}"></span>${env}</span>`;
+  }).join('');
+}
+
+function renderStats() {
+  const grid = document.getElementById('stats-grid');
+  grid.innerHTML = '';
+  for (const { key, label } of KEY_METRICS) {
+    const card = document.createElement('div');
+    card.className = 'stat-card';
+    let valHtml = '';
+    for (const env of allEnvs()) {
+      const durations = (datasets[env].samples || [])
+        .filter(s => s.step === key && s.duration_ms != null)
+        .map(s => s.duration_ms);
+      const med = median(durations);
+      const cls = envClass(env);
+      valHtml += med != null
+        ? `<span class="stat-val ${cls}">${med.toFixed(0)}</span>`
+        : `<span class="stat-val" style="color:#475569">—</span>`;
+    }
+    card.innerHTML = `
+      <div class="stat-label">${label}</div>
+      <div class="stat-values">${valHtml}<span class="stat-unit">ms median</span></div>`;
+    grid.appendChild(card);
+  }
+}
+
+function renderCharts() {
+  const steps = allSteps();
+  const envs  = allEnvs();
+
+  function buildDatasets(statFn) {
+    return envs.map(env => {
+      const byStep = groupByStep(datasets[env].samples);
+      return { env, data: steps.map(s => { const v = statFn(byStep[s] || []); return v ?? null; }) };
+    });
+  }
+
+  renderLegend('legend-median');
+  makeBarChart('chart-median', steps, buildDatasets(median));
+
+  renderLegend('legend-p95');
+  makeBarChart('chart-p95', steps, buildDatasets(arr => percentile(arr, 95)));
+}
+
+function renderTable() {
+  const tbody = document.getElementById('raw-tbody');
+  const stepSel = document.getElementById('filter-step').value;
+  const envSel  = document.getElementById('filter-env').value;
+
+  let rows = allSamples();
+  if (stepSel) rows = rows.filter(r => r.step === stepSel);
+  if (envSel)  rows = rows.filter(r => r._env === envSel);
+
+  // Sort newest first (if timestamp present), else leave order
+  rows.sort((a, b) => {
+    if (a.timestamp && b.timestamp) return b.timestamp.localeCompare(a.timestamp);
+    return 0;
+  });
+
+  tbody.innerHTML = rows.slice(0, 500).map(r => {
+    const envCls = envClass(r._env);
+    const ms = r.duration_ms != null ? r.duration_ms.toFixed(1) : '—';
+    const ts = r.timestamp ? r.timestamp.replace('T', ' ').replace(/\.\d+Z$/, 'Z') : '—';
+    const correct = r.correct != null ? (r.correct ? '✓' : '✗') : '—';
+    return `<tr>
+      <td class="${envCls}">${r._env}</td>
+      <td class="step">${r.step}</td>
+      <td>${ms}</td>
+      <td>${r.lang ?? r.language ?? '—'}</td>
+      <td>${correct}</td>
+      <td>${r.best_sim != null ? r.best_sim.toFixed(1) : '—'}</td>
+      <td>${ts}</td>
+    </tr>`;
+  }).join('');
+}
+
+function populateFilters() {
+  const steps = allSteps();
+  const stepSel = document.getElementById('filter-step');
+  stepSel.innerHTML = '<option value="">All steps</option>' +
+    steps.map(s => `<option value="${s}">${s}</option>`).join('');
+
+  const envSel = document.getElementById('filter-env');
+  envSel.innerHTML = '<option value="">All envs</option>' +
+    allEnvs().map(e => `<option value="${e}">${e}</option>`).join('');
+}
+
+function renderAll() {
+  if (!allEnvs().length) return;
+  document.getElementById('hint').style.display = 'none';
+  document.getElementById('dashboard').style.display = 'block';
+  renderStats();
+  renderCharts();
+  populateFilters();
+  renderTable();
+}
+
+// ─────────────────────────────────────────────
+// File loading
+// ─────────────────────────────────────────────
+function loadFile(file, slot) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    let data;
+    try {
+      data = JSON.parse(e.target.result);
+    } catch (err) {
+      alert(`Could not parse ${file.name} as JSON: ${err.message}`);
+      return;
+    }
+
+    const env    = data.env || slot;
+    const samples = Array.isArray(data.samples) ? data.samples : [];
+    const count  = data.sample_count ?? samples.length;
+    const collAt = data.collected_at ? data.collected_at.slice(0, 16).replace('T', ' ') : '—';
+
+    datasets[env] = { meta: data, samples };
+
+    const card   = document.getElementById(`card-${slot}`);
+    const metaEl = document.getElementById(`meta-${slot}`);
+    card.classList.add('loaded');
+    metaEl.innerHTML = `
+      <span class="env-badge ${badgeClass(env)}">${env}</span>
+      <div class="meta-text">${count} samples · collected ${collAt} UTC</div>`;
+
+    renderAll();
+  };
+  reader.readAsText(file);
+}
+
+document.getElementById('file-a').addEventListener('change', e => {
+  if (e.target.files[0]) loadFile(e.target.files[0], 'a');
+});
+document.getElementById('file-b').addEventListener('change', e => {
+  if (e.target.files[0]) loadFile(e.target.files[0], 'b');
+});
+
+document.getElementById('filter-step').addEventListener('change', renderTable);
+document.getElementById('filter-env').addEventListener('change', renderTable);
+</script>
+</body>
+</html>


### PR DESCRIPTION
- tools/collect_metrics.py: parses [TIMING] log lines from a local log
  file or GCP Cloud Logging (via gcloud CLI) and writes a normalised
  JSON file ready for the dashboard
- tools/dashboard.html: zero-dependency standalone HTML dashboard that
  accepts two metrics JSON files (e.g. local + GCP), renders median and
  p95 bar charts per step, key metric stat cards, and a filterable raw
  samples table — opens directly from the filesystem, no server needed

https://claude.ai/code/session_01UQ35hvtf6cf63GYyafgt3D