### PR TITLE
Fix settings save error: robust content-length parsing, no-cache headers, better error messages

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -197,11 +197,17 @@ async function saveSettings() {
     setup_complete: true,
   };
 
-  const resp = await fetch('/api/config', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(config),
-  });
+  let resp;
+  try {
+    resp = await fetch('/api/config', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(config),
+    });
+  } catch (err) {
+    alert(`Network error – could not reach server.\n${err.message}`);
+    return;
+  }
 
   if (resp.ok) {
     localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
@@ -209,7 +215,14 @@ async function saveSettings() {
     fb.classList.remove('hidden');
     setTimeout(() => { fb.classList.add('hidden'); window.location.href = '/'; }, 1500);
   } else {
-    alert('Save failed – check the server console.');
+    let detail = '';
+    try {
+      const body = await resp.json();
+      detail = body.detail || JSON.stringify(body);
+    } catch (_) {
+      detail = await resp.text().catch(() => '');
+    }
+    alert(`Save failed (HTTP ${resp.status})${detail ? ':\n' + detail : '.'}`);
   }
 }
 </script>


### PR DESCRIPTION
- main.py: Wrap content-length header parse in try/except to handle missing
  or malformed headers in proxied Cloud Run environment (ValueError on empty
  string, TypeError on None)
- main.py: Wrap request.json() parse in try/except to return HTTP 400 instead
  of unhandled 500 on malformed JSON bodies
- main.py: Add Cache-Control: no-store headers to HTML page routes (/ and
  /settings) so Cloud CDN never serves stale cached HTML
- templates/config.html: Add try/catch around fetch() to surface network
  errors clearly instead of silently failing
- templates/config.html: On non-ok HTTP response, read and display the actual
  status code and FastAPI error detail instead of the generic
  "check the server console" message

https://claude.ai/code/session_01PsyJnAi7RDgRktMrkceia2