### PR TITLE
Fix back button layout and switch to Baloo 2 font

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -18,8 +18,8 @@
   --card-bg:    rgba(255,255,255,0.85);
   --shadow:     0 8px 32px rgba(155,89,182,0.18);
   --radius:     24px;
-  --font-main:  'Nunito', 'Fredoka One', sans-serif;
-  --font-title: 'Fredoka One', 'Nunito', sans-serif;
+  --font-main:  'Nunito', 'Baloo 2', sans-serif;
+  --font-title: 'Baloo 2', 'Nunito', sans-serif;
 }
 
 /* ── Reset & Base ──────────────────────────────────── */
@@ -60,7 +60,7 @@ header h1 {
   letter-spacing: 1px;
 }
 
-.settings-btn, .back-btn {
+.settings-btn {
   font-size: 1.6rem;
   text-decoration: none;
   color: var(--white);
@@ -73,7 +73,24 @@ header h1 {
   justify-content: center;
   transition: background 0.2s;
 }
-.settings-btn:hover, .back-btn:hover { background: rgba(255,255,255,0.38); }
+.settings-btn:hover { background: rgba(255,255,255,0.38); }
+
+.back-btn {
+  font-family: var(--font-title);
+  font-size: 1rem;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--white);
+  background: rgba(255,255,255,0.2);
+  border-radius: 50px;
+  padding: 0.35rem 1rem 0.35rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+.back-btn:hover { background: rgba(255,255,255,0.38); }
 
 /* ── Main layout ───────────────────────────────────── */
 main {

--- a/templates/config.html
+++ b/templates/config.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
   <link rel="stylesheet" href="/static/css/style.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;900&display=swap" rel="stylesheet" />
 </head>
 <body class="settings-page">
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
   <link rel="stylesheet" href="/static/css/style.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;900&display=swap" rel="stylesheet" />
 </head>
 <body>
 


### PR DESCRIPTION
- Back button was styled as a fixed 2.4rem circle (border-radius: 50%) but contained "← Back" text that overflowed; now a pill-shaped button with proper padding so the arrow and label fit correctly
- Replaced Fredoka One with Baloo 2 (softer, rounder, friendlier for toddlers) in both HTML font imports and the CSS font-title variable

https://claude.ai/code/session_01UAqZ9YmaPiQpmuirumhNK8