### PR TITLE
Add --server-url flag to enable Mac mini as Whisper host

### DIFF
--- a/src/robot_teacher.py
+++ b/src/robot_teacher.py
@@ -279,7 +279,9 @@ def _make_session() -> requests.Session:
 _session = _make_session()
 
 
-def resolve_server_url(runtime_mode: str) -> str:
+def resolve_server_url(runtime_mode: str, server_url: str = "") -> str:
+    if server_url:
+        return server_url
     if runtime_mode == "cloud":
         return CLOUD_SERVER_URL
     if runtime_mode == "reachy_local":
@@ -287,14 +289,14 @@ def resolve_server_url(runtime_mode: str) -> str:
     raise ValueError(f"Unknown runtime_mode '{runtime_mode}'")
 
 
-def configure_server_url(runtime_mode: str) -> str:
+def configure_server_url(runtime_mode: str, server_url: str = "") -> str:
     global SERVER_URL
-    SERVER_URL = resolve_server_url(runtime_mode)
+    SERVER_URL = resolve_server_url(runtime_mode, server_url)
     return SERVER_URL
 
 
-def should_start_local_server(runtime_mode: str, no_server: bool) -> bool:
-    return runtime_mode == "reachy_local" and not no_server
+def should_start_local_server(runtime_mode: str, no_server: bool, server_url: str = "") -> bool:
+    return runtime_mode == "reachy_local" and not no_server and not server_url
 
 
 # ── HTTP client wrappers ───────────────────────────────────────────────────────
@@ -1523,6 +1525,13 @@ def main():
         help="Recording attempts per word before revealing the answer",
     )
     parser.add_argument(
+        "--server-url",
+        default="",
+        metavar="URL",
+        help="Override server URL (e.g. http://192.168.1.x:8765). "
+             "Skips local server startup. Use for Mac mini or any LAN host.",
+    )
+    parser.add_argument(
         "--no-server",
         action="store_true",
         help="Only for reachy_local: use an already-running local Myra server instead of auto-starting one",
@@ -1600,11 +1609,11 @@ def main():
     if not categories:
         parser.error("--categories produced an empty list. Check the value.")
 
-    configure_server_url(runtime_mode)
+    configure_server_url(runtime_mode, args.server_url)
 
     # ── Server subprocess ──────────────────────────────────────────────────────
     server_proc = None
-    if should_start_local_server(runtime_mode, args.no_server):
+    if should_start_local_server(runtime_mode, args.no_server, args.server_url):
         server_proc = start_myra_server(
             app_dir=args.server_dir,
             words_sync_to_gcs=words_sync_to_gcs,

--- a/tasks/plan-reachy-integration.md
+++ b/tasks/plan-reachy-integration.md
@@ -12,15 +12,15 @@ The Myra app is already a REST API. The robot integration is a new Python script
 
 There are two deployment options depending on how much you want to set up on the Pi:
 
-| | Option A | Option B |
-|--|---------|---------|
-| **Where Myra server runs** | GCP Cloud Run (already deployed) | On the Pi itself |
-| **Laptop needed?** | No | No |
-| **Internet needed?** | Yes (WiFi on robot) | Yes (gTTS needs Google) |
-| **Setup effort** | Low — only install robot SDK on Pi | Medium — full app install on Pi |
-| **Whisper runs on** | GCP (1 vCPU, fast) | Pi 5 CPU (~1–3s per word) |
-| **Works offline?** | No | No (gTTS still needs internet) |
-| **Best for** | Getting started quickly | Production / classroom use |
+| | Option A | Option B | Option C |
+|--|---------|---------|---------|
+| **Where Myra server runs** | GCP Cloud Run (already deployed) | On the Pi itself | Mac mini (LAN) |
+| **Laptop needed?** | No | No | Mac mini must be on |
+| **Internet needed?** | Yes (WiFi on robot) | Yes (gTTS needs Google) | Yes (gTTS only) |
+| **Setup effort** | Low — only install robot SDK on Pi | Medium — full app install on Pi | Low — clone + pip install on Mac mini |
+| **Whisper runs on** | GCP (1 vCPU, fast) | Pi 5 CPU (~200ms, single-pass) | Mac mini CPU/Neural Engine (full dual-pass) |
+| **Works offline?** | No | No (gTTS still needs internet) | No (gTTS still needs internet) |
+| **Best for** | Getting started quickly | Production / classroom use | **Best Assamese accuracy** (see [#1](https://github.com/theroadrunnershow/myra-language-teacher/issues/1)) |
 
 ---
 
@@ -238,6 +238,86 @@ sudo systemctl enable myra
 sudo systemctl start myra
 # Then run robot_teacher.py with --no-server flag
 ```
+
+---
+
+## Option C: Mac Mini (Best Whisper Quality)
+
+### How it works
+
+```
+┌─────────────────────────────┐   LAN    ┌──────────────────────────┐
+│     Reachy Mini (Pi 5)      │          │  Mac mini                │
+│                             │  HTTP    │  (same local network)    │
+│  robot_teacher.py  ─────────┼─────────►│                          │
+│  (lesson loop,              │          │  uvicorn main:app        │
+│   animations,               │          │  port 8765               │
+│   audio bridge)             │          │                          │
+│                             │          │  Whisper tiny            │
+│  4 mics  │  speaker         │          │  full dual-pass ✓        │
+└─────────────────────────────┘          └────────────┬─────────────┘
+                                                      │ gTTS
+                                                      ▼
+                                              Google TTS API
+```
+
+The Pi runs `robot_teacher.py` only. The Mac mini runs the full Myra FastAPI server
+with Whisper. Because `DISABLE_PASS1` is **not** set, both recognition passes run —
+native-script pass + English/romanized pass — giving the best accuracy for Assamese
+(see [#1](https://github.com/theroadrunnershow/myra-language-teacher/issues/1)).
+
+### Mac mini setup (one-time)
+
+```bash
+# Clone repo
+git clone <repo-url> myra-language-teacher
+cd myra-language-teacher
+
+# Install deps (brew install ffmpeg if needed)
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Find your Mac mini's local IP
+ipconfig getifaddr en0
+```
+
+### Mac mini: start the server
+
+```bash
+source venv/bin/activate
+# Bind to 0.0.0.0 so the Pi can reach it over LAN
+PYTHONPATH=src uvicorn main:app --host 0.0.0.0 --port 8765
+```
+
+Do **not** set `DISABLE_PASS1` — the Mac mini can handle full dual-pass.
+
+### Pi: run robot_teacher.py pointing at Mac mini
+
+```bash
+# Replace 192.168.1.x with your Mac mini's actual local IP
+python robot_teacher.py --server-url http://192.168.1.x:8765 \
+  --language assamese --categories animals,colors,food,numbers --words 10
+```
+
+The `--server-url` flag skips local server startup entirely — no subprocess is spawned on the Pi.
+
+### Pros
+- Full dual-pass Whisper → better Assamese and Telugu recognition accuracy
+- Mac mini CPU (or M-series Neural Engine) is dramatically faster than Pi
+- No GCP billing for robot sessions
+- Low latency: LAN round-trip is ~1–5ms vs internet round-trip
+
+### Cons
+- Mac mini must be powered on and running during the lesson
+- Still needs internet for gTTS
+
+### Implementation
+
+Added `--server-url` flag to `robot_teacher.py` (see `src/robot_teacher.py`):
+- `resolve_server_url(runtime_mode, server_url)` — custom URL takes priority over mode
+- `should_start_local_server(runtime_mode, no_server, server_url)` — returns `False` when URL provided
+- No changes to server code needed
 
 ---
 

--- a/tests/test_robot_teacher.py
+++ b/tests/test_robot_teacher.py
@@ -143,6 +143,20 @@ def test_should_start_local_server_only_in_reachy_local_mode():
     assert should_start_local_server("cloud", no_server=False) is False
 
 
+def test_resolve_server_url_with_custom_url():
+    """--server-url overrides both cloud and reachy_local modes."""
+    custom = "http://192.168.1.50:8765"
+    assert resolve_server_url("cloud", custom) == custom
+    assert resolve_server_url("reachy_local", custom) == custom
+
+
+def test_should_start_local_server_false_when_server_url_provided():
+    """No subprocess spawned when a custom --server-url is given."""
+    assert should_start_local_server(
+        "reachy_local", no_server=False, server_url="http://192.168.1.50:8765"
+    ) is False
+
+
 def test_listen_handles_motion_errors(caplog):
     mini = _FakeMini()
     controller = RobotController(mini)


### PR DESCRIPTION
Adds a --server-url flag to robot_teacher.py so the robot can point at
any LAN host (e.g. Mac mini) running the Myra FastAPI server. This
re-enables full dual-pass Whisper without the DISABLE_PASS1 penalty,
improving Assamese recognition accuracy (see #1).

- resolve_server_url(), configure_server_url(), should_start_local_server()
  all accept an optional server_url override that takes priority over mode
- No subprocess is spawned on the Pi when --server-url is set
- 2 new tests covering the override behaviour (17 total robot tests)
- Option C (Mac mini) section added to tasks/plan-reachy-integration.md

https://claude.ai/code/session_01E5rACtnM5m8oV44n9EigPr