### PR TITLE
feat: default kids-teacher realtime model to gpt-realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Backend model:
 | Variable                       | Default            | Purpose |
 | ------------------------------ | ------------------ | ------- |
 | `OPENAI_API_KEY`               | _(required)_       | OpenAI credentials for the realtime session |
-| `KIDS_TEACHER_REALTIME_MODEL`  | `gpt-realtime-mini`| Model name. Only `gpt-realtime` and `gpt-realtime-mini` are accepted |
+| `KIDS_TEACHER_REALTIME_MODEL`  | `gpt-realtime`     | Model name. Only `gpt-realtime` and `gpt-realtime-mini` are accepted |
 
 Review storage (both default **OFF**; enable explicitly per deployment):
 

--- a/src/kids_teacher_backend.py
+++ b/src/kids_teacher_backend.py
@@ -28,7 +28,7 @@ from kids_teacher_types import (
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_REALTIME_MODEL = "gpt-realtime-mini"
+DEFAULT_REALTIME_MODEL = "gpt-realtime"
 REALTIME_MODEL_ENV_VAR = "KIDS_TEACHER_REALTIME_MODEL"
 
 # Transcription model used by OpenAI Realtime for input transcripts.
@@ -66,7 +66,7 @@ def _encode_audio_chunk(chunk: bytes) -> str:
 
 
 def resolve_realtime_model(env_value: Optional[str] = None) -> str:
-    """Return the realtime model from env, defaulting to gpt-realtime-mini.
+    """Return the realtime model from env, defaulting to gpt-realtime.
 
     - ``env_value=None`` reads :data:`REALTIME_MODEL_ENV_VAR` from the
       process environment.

--- a/src/kids_teacher_routes.py
+++ b/src/kids_teacher_routes.py
@@ -60,7 +60,7 @@ def _get_model() -> str:
         logger.warning("[kids_teacher_routes] resolve_realtime_model failed: %s", exc)
         # Fall back to the documented default so /status does not 500 when
         # the env value is temporarily invalid.
-        return "gpt-realtime-mini"
+        return "gpt-realtime"
 
 
 def _default_enabled_languages() -> list[str]:


### PR DESCRIPTION
Switch the default from the light gpt-realtime-mini to the recommended
full gpt-realtime. Env var KIDS_TEACHER_REALTIME_MODEL still overrides.

https://claude.ai/code/session_011LR1iJcF9eA241tXKFoPqz