### PR TITLE
Add persistent memory feature spec and design doc

### DIFF
--- a/tasks/plan-persistent-memory.md
+++ b/tasks/plan-persistent-memory.md
@@ -1,0 +1,145 @@
+# Plan: Persistent Memory ("Robot That Remembers Myra")
+
+## Context
+
+The robot should accumulate memory of the child across sessions, devices, and
+reinstalls so it can:
+
+- Greet her with continuity ("last time we worked on Telugu animals")
+- Run spaced repetition on words she's actually struggling with
+- Reference family members, favorites, and shared moments to feel personal
+- Resume narratives and inside jokes across days/weeks
+
+Today every state lives in-process or in `sessionStorage`; nothing survives a
+restart, let alone a reinstall.
+
+## Design constraints
+
+- **Long-lived & device-independent.** Memory must outlive `apt purge`, SD-card
+  reflashes, browser-cache clears, and moves between robot and web client.
+- **Child-keyed, not device-keyed.** The primary key is the child, not the
+  hardware. Multiple devices for the same child must converge.
+- **Tight LLM context budget.** Gemini system instructions can't hold a year of
+  history; memory has to be compressible to a ≤500-token preamble.
+- **Privacy first.** This is a 4-year-old's data. Admin-only access, explicit
+  delete path, no PII beyond first name + stated family relations.
+- **Offline-tolerant.** A robot with no internet should still run a session;
+  memory writes can buffer and flush later.
+
+## Identity
+
+Primary key: `child_id` — a stable string set via the admin config flow
+(parent picks/types it once; "myra" is fine). Re-entered post-reinstall in
+<30s, or auto-recovered from the planned face-recognition encodings.
+
+Secondary key: `device_id` — robot serial # on Reachy, localStorage UUID on
+web. Used for telemetry and last-seen, never as the lookup key.
+
+## Memory taxonomy
+
+Four categories, separated because their access patterns differ:
+
+| Kind        | Examples                                  | Read freq | Write freq | Store     |
+|-------------|-------------------------------------------|-----------|------------|-----------|
+| Semantic    | name, age, family, favorite animal        | each session start | rare | Firestore doc |
+| Procedural  | per-word mastery (attempts, ease, last_seen) | every turn | every turn | Firestore subcoll |
+| Episodic    | session timestamp, words covered, mood    | rare (recap) | end of session | GCS JSONL |
+| Affective   | excites/frustrates/jokes                  | each session start | weekly summarizer | Firestore doc |
+
+## Storage layout
+
+```
+Firestore:
+  memory/{child_id}                          # semantic + affective doc
+    schema_version: 1
+    child:        { name, age, languages, family: [...] }
+    affect:       { excites: [...], frustrates: [...], jokes: [...] }
+    last_session: { device_id, ended_at, summary_text }
+
+  memory/{child_id}/mastery/{english_word}   # procedural — one doc per word
+    attempts: int
+    successes: int
+    ease: float
+    last_seen: timestamp
+    languages_seen: [...]
+
+GCS:
+  gs://{bucket}/memory/{child_id}/episodes/{YYYY-MM}.jsonl
+                                              # append one line per session
+```
+
+Local cache: SQLite at `~/.myra/memory.db` on robot, IndexedDB on web. Read
+on boot, write-through on update, periodic reconcile against the cloud.
+
+## Retrieval (hot path)
+
+Session start:
+
+1. Read `memory/{child_id}` (1 doc, <2 KB).
+2. Read top-N due-for-review mastery docs (`last_seen + ease_interval < now`).
+3. Compose a preamble string (~300 tokens) and inject into Gemini system
+   instructions. Example:
+   > You're talking with Myra (4). She loves tigers; her little brother is
+   > Ahaan. Last session she nailed Telugu colors but stumbled on "water"
+   > (పానీయం). Today try animals + revisit "water" once.
+4. Don't pull episodes into context; the semantic+affective doc is the
+   compressed view of them.
+
+## Writes (cold path)
+
+End of session:
+
+1. Aggregate the in-memory turn log into:
+   - Episode JSONL line → append to month blob in GCS
+   - Mastery patches → batched Firestore writes (one per word touched)
+   - Affective deltas → optional, only when something notable surfaces
+2. Re-summarize `last_session.summary_text` (~2 sentences) so next session's
+   preamble has fresh context.
+3. Weekly cron / app-startup task: re-summarize affective signals from the
+   last 30 days of episodes; trim episodes older than 1 year.
+
+Sync policy mirrors `dynamic_words_store`: `never` / `session_end` /
+`shutdown`.
+
+## LLM integration
+
+- New helper `build_memory_preamble(child_id) -> str` consumed by both
+  `kids_teacher_backend` and `kids_teacher_gemini_backend`.
+- Bounded length (hard cap ~500 tokens; truncate oldest first).
+- Falls back to an empty string when memory is missing or fetch fails — never
+  blocks session start.
+
+## Privacy & admin
+
+- Admin-only routes: `GET /admin/memory/{child_id}` (view), `DELETE` (cascade
+  delete Firestore + GCS), `POST /admin/memory/{child_id}/redact` (drop
+  affective + episodic, keep mastery).
+- Memory writes gated by the existing kids-safety review filter; anything
+  flagged is dropped before reaching cloud.
+- No raw audio in memory — that's `kids_review_store`'s job, kept separate.
+- Schema versioned so future migrations don't strand old data.
+
+## Open questions to resolve before coding
+
+1. Firestore vs. just-GCS for the hot path. Firestore is new dependency; one
+   alternative is a single JSON blob in GCS keyed by child_id, read-modify-
+   write at session boundaries. Simpler, fine until mastery grows past ~1 K
+   words.
+2. Web client identity — does the parent type `child_id` once and we trust
+   the browser, or do we require Google sign-in? Family-only deployment can
+   probably get away with the typed-once model.
+3. Local cache: do we ship offline-first from day one, or cloud-only v1 and
+   add caching when a real offline scenario shows up?
+4. Multi-child households — out of scope for v1 (Myra-only) but the schema
+   above supports it without changes.
+
+## Rollout sketch
+
+1. v1: Single GCS blob per child, semantic + last-3-sessions summary only.
+   No mastery yet. Memory preamble works. ~2 days.
+2. v2: Add mastery (Firestore subcollection or expand the blob), drive
+   spaced-repetition word selection. ~3 days.
+3. v3: Episodic JSONL + weekly summarizer. ~2 days.
+4. v4: Local cache + offline tolerance. Only if a real need emerges.
+
+Each step shipping with tests before moving on.

--- a/tasks/plan-persistent-memory.md
+++ b/tasks/plan-persistent-memory.md
@@ -2,144 +2,178 @@
 
 ## Context
 
-The robot should accumulate memory of the child across sessions, devices, and
-reinstalls so it can:
+The kids-teacher flow on Reachy Mini should accumulate memory across sessions
+so the robot can:
 
-- Greet her with continuity ("last time we worked on Telugu animals")
+- Greet with continuity ("last time we worked on Telugu animals")
 - Run spaced repetition on words she's actually struggling with
 - Reference family members, favorites, and shared moments to feel personal
 - Resume narratives and inside jokes across days/weeks
 
-Today every state lives in-process or in `sessionStorage`; nothing survives a
-restart, let alone a reinstall.
+Today every state lives in-process; nothing survives a restart.
 
-## Design constraints
+## Scope
 
-- **Long-lived & device-independent.** Memory must outlive `apt purge`, SD-card
-  reflashes, browser-cache clears, and moves between robot and web client.
-- **Child-keyed, not device-keyed.** The primary key is the child, not the
-  hardware. Multiple devices for the same child must converge.
-- **Tight LLM context budget.** Gemini system instructions can't hold a year of
-  history; memory has to be compressible to a ≤500-token preamble.
-- **Privacy first.** This is a 4-year-old's data. Admin-only access, explicit
-  delete path, no PII beyond first name + stated family relations.
-- **Offline-tolerant.** A robot with no internet should still run a session;
-  memory writes can buffer and flush later.
+- **Reachy-only.** Web client is out of scope. The kids-teacher flow only runs
+  on the Pi-hosted robot.
+- **Single child per device.** One Reachy = one child. No multi-tenancy, no
+  `child_id` keying. If we ever need it, the schema below trivially extends.
+- **Kids-teacher flow only.** No reuse from the legacy lesson page or the
+  word-DB editor.
 
-## Identity
+## Storage: local SQLite on the Pi
 
-Primary key: `child_id` — a stable string set via the admin config flow
-(parent picks/types it once; "myra" is fine). Re-entered post-reinstall in
-<30s, or auto-recovered from the planned face-recognition encodings.
+Path: `~/.myra/memory.db` (override via `MYRA_MEMORY_DB_PATH`).
 
-Secondary key: `device_id` — robot serial # on Reachy, localStorage UUID on
-web. Used for telemetry and last-seen, never as the lookup key.
+Why SQLite over a JSON file:
+- Atomic writes — matters for crashes mid-session
+- Queries for spaced repetition (`WHERE next_due <= now ORDER BY next_due`)
+- Cheap schema migrations (`schema_version` table + idempotent `ALTER`s)
+- Single file, no daemon, `sqlite3` is in the stdlib
 
-## Memory taxonomy
+What "persistent" actually buys us:
+- Reboots: ✓ (filesystem)
+- App reinstall / `pip install` / `git pull`: ✓ (data lives outside the
+  package)
+- `apt reinstall` of the Myra package: ✓ (DB is in `~/.myra/`, not in any
+  packaged dir)
+- SD-card reflash: ✗ — accept this, mitigate with an optional backup script
+  (`scripts/backup_memory.py` → copy to USB or email). Not required for v1.
 
-Four categories, separated because their access patterns differ:
+No cloud. No Firestore. No GCS. Memory never leaves the device, which is
+strictly better for a 4-year-old's data.
 
-| Kind        | Examples                                  | Read freq | Write freq | Store     |
-|-------------|-------------------------------------------|-----------|------------|-----------|
-| Semantic    | name, age, family, favorite animal        | each session start | rare | Firestore doc |
-| Procedural  | per-word mastery (attempts, ease, last_seen) | every turn | every turn | Firestore subcoll |
-| Episodic    | session timestamp, words covered, mood    | rare (recap) | end of session | GCS JSONL |
-| Affective   | excites/frustrates/jokes                  | each session start | weekly summarizer | Firestore doc |
+## Schema
 
-## Storage layout
+```sql
+CREATE TABLE schema_version (version INTEGER NOT NULL);
 
+-- singleton row
+CREATE TABLE child (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    name TEXT NOT NULL,
+    age INTEGER,
+    languages TEXT,                 -- JSON array
+    family TEXT,                    -- JSON: [{relation, name}, ...]
+    updated_at TEXT NOT NULL
+);
+
+-- singleton row, refreshed by the weekly summarizer
+CREATE TABLE affect (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    excites TEXT,                   -- JSON array
+    frustrates TEXT,                -- JSON array
+    jokes TEXT,                     -- JSON array
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE mastery (
+    english TEXT NOT NULL,
+    language TEXT NOT NULL,         -- 'telugu' | 'assamese' | ...
+    attempts INTEGER NOT NULL DEFAULT 0,
+    successes INTEGER NOT NULL DEFAULT 0,
+    ease REAL NOT NULL DEFAULT 2.5, -- SM-2 style
+    last_seen TEXT,
+    next_due TEXT,
+    PRIMARY KEY (english, language)
+);
+CREATE INDEX idx_mastery_due ON mastery(next_due);
+
+CREATE TABLE episodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    started_at TEXT NOT NULL,
+    ended_at TEXT NOT NULL,
+    words_covered TEXT,             -- JSON array of english words
+    mood TEXT,                      -- 'engaged'|'frustrated'|'tired'|...
+    summary TEXT                    -- one-line LLM-written recap
+);
+CREATE INDEX idx_episodes_ended_at ON episodes(ended_at);
 ```
-Firestore:
-  memory/{child_id}                          # semantic + affective doc
-    schema_version: 1
-    child:        { name, age, languages, family: [...] }
-    affect:       { excites: [...], frustrates: [...], jokes: [...] }
-    last_session: { device_id, ended_at, summary_text }
 
-  memory/{child_id}/mastery/{english_word}   # procedural — one doc per word
-    attempts: int
-    successes: int
-    ease: float
-    last_seen: timestamp
-    languages_seen: [...]
-
-GCS:
-  gs://{bucket}/memory/{child_id}/episodes/{YYYY-MM}.jsonl
-                                              # append one line per session
-```
-
-Local cache: SQLite at `~/.myra/memory.db` on robot, IndexedDB on web. Read
-on boot, write-through on update, periodic reconcile against the cloud.
+`schema_version` starts at 1. Migrations: `memory_store.migrate()` runs on
+open and is idempotent.
 
 ## Retrieval (hot path)
 
-Session start:
+Session start, in `kids_teacher_flow` (or backend init):
 
-1. Read `memory/{child_id}` (1 doc, <2 KB).
-2. Read top-N due-for-review mastery docs (`last_seen + ease_interval < now`).
-3. Compose a preamble string (~300 tokens) and inject into Gemini system
-   instructions. Example:
-   > You're talking with Myra (4). She loves tigers; her little brother is
-   > Ahaan. Last session she nailed Telugu colors but stumbled on "water"
-   > (పానీయం). Today try animals + revisit "water" once.
-4. Don't pull episodes into context; the semantic+affective doc is the
-   compressed view of them.
+1. `child = memory_store.get_child()` — 1 row.
+2. `affect = memory_store.get_affect()` — 1 row.
+3. `due = memory_store.due_for_review(limit=5)` — words past `next_due`.
+4. `recap = memory_store.last_session_summary()` — newest `episodes.summary`.
+5. `build_memory_preamble(child, affect, due, recap) -> str` — hard cap
+   ~500 tokens, truncate `due` first if needed. Inject into the system
+   instructions for both `kids_teacher_backend` and
+   `kids_teacher_gemini_backend`.
+
+Failure mode: any DB error → return empty preamble, log a warning, never
+block session start.
 
 ## Writes (cold path)
 
-End of session:
+End of session, in `kids_teacher_flow`:
 
-1. Aggregate the in-memory turn log into:
-   - Episode JSONL line → append to month blob in GCS
-   - Mastery patches → batched Firestore writes (one per word touched)
-   - Affective deltas → optional, only when something notable surfaces
-2. Re-summarize `last_session.summary_text` (~2 sentences) so next session's
-   preamble has fresh context.
-3. Weekly cron / app-startup task: re-summarize affective signals from the
-   last 30 days of episodes; trim episodes older than 1 year.
+1. For each word touched: `memory_store.record_attempt(word, language,
+   correct: bool)` — updates `attempts/successes`, recomputes `ease` and
+   `next_due` (SM-2-ish, kept simple: 1d / 3d / 7d / 14d ladder gated on
+   success).
+2. `memory_store.append_episode(started_at, ended_at, words_covered, mood,
+   summary)` — `summary` is a 1–2 sentence string the LLM produces at
+   session-end (cheap; we already have a turn log).
+3. Affect updates are *not* per-session. A weekly task (or app-startup
+   check) re-summarizes the last N episodes into the affect row. Out of
+   scope for v1 — start with manual updates via admin CLI.
 
-Sync policy mirrors `dynamic_words_store`: `never` / `session_end` /
-`shutdown`.
+All writes are inside a single `with conn:` transaction so a crash leaves
+the DB consistent.
 
-## LLM integration
+## Files to add / touch
 
-- New helper `build_memory_preamble(child_id) -> str` consumed by both
-  `kids_teacher_backend` and `kids_teacher_gemini_backend`.
-- Bounded length (hard cap ~500 tokens; truncate oldest first).
-- Falls back to an empty string when memory is missing or fetch fails — never
-  blocks session start.
+- `src/memory_store.py` — new. Public API:
+  - `open(path: str | None = None) -> Connection`
+  - `migrate(conn)`
+  - `get_child(conn) -> dict | None`
+  - `set_child(conn, **fields)`
+  - `get_affect(conn) -> dict`
+  - `due_for_review(conn, limit=5) -> list[dict]`
+  - `record_attempt(conn, english, language, correct)`
+  - `append_episode(conn, **fields)`
+  - `last_session_summary(conn) -> str | None`
+- `src/memory_preamble.py` — pure function `build_memory_preamble(...)`
+  → `str`. Keeps prompt-shaping out of the store.
+- `src/kids_teacher_backend.py` + `kids_teacher_gemini_backend.py` —
+  inject preamble into system instructions. One call site each.
+- `src/kids_teacher_flow.py` — record attempts + append episode on
+  session end. Hooked into the existing end-of-session path.
+- `tests/test_memory_store.py` — DB lifecycle, migrations, SR scheduling,
+  due-for-review correctness, transaction rollback on error.
+- `tests/test_memory_preamble.py` — preamble shape, token cap, graceful
+  empties.
+- `tests/test_kids_teacher_flow.py` (extend) — assert attempts + episodes
+  written on session end.
+- `scripts/backup_memory.py` — *optional, deferred.* Copy DB to a path
+  (USB / scp). Only if SD-reflash recovery becomes a real need.
 
-## Privacy & admin
+## Open questions
 
-- Admin-only routes: `GET /admin/memory/{child_id}` (view), `DELETE` (cascade
-  delete Firestore + GCS), `POST /admin/memory/{child_id}/redact` (drop
-  affective + episodic, keep mastery).
-- Memory writes gated by the existing kids-safety review filter; anything
-  flagged is dropped before reaching cloud.
-- No raw audio in memory — that's `kids_review_store`'s job, kept separate.
-- Schema versioned so future migrations don't strand old data.
+1. **DB path.** `~/.myra/memory.db` follows XDG-ish convention; alternative
+   is `/var/lib/myra/memory.db` if we want it survivable across user
+   account changes. Recommend `~/.myra/` for now (simpler perms).
+2. **Mood detection.** `episodes.mood` is easy if the LLM tags it at
+   session-end; punt to a follow-up if that's not free.
+3. **Spaced-repetition aggressiveness.** Start with a fixed 1d / 3d / 7d /
+   14d ladder; tune later if Myra's retention curve says otherwise.
+4. **Backup story.** Defer until reflash actually loses something the
+   parent cares about.
 
-## Open questions to resolve before coding
+## Rollout
 
-1. Firestore vs. just-GCS for the hot path. Firestore is new dependency; one
-   alternative is a single JSON blob in GCS keyed by child_id, read-modify-
-   write at session boundaries. Simpler, fine until mastery grows past ~1 K
-   words.
-2. Web client identity — does the parent type `child_id` once and we trust
-   the browser, or do we require Google sign-in? Family-only deployment can
-   probably get away with the typed-once model.
-3. Local cache: do we ship offline-first from day one, or cloud-only v1 and
-   add caching when a real offline scenario shows up?
-4. Multi-child households — out of scope for v1 (Myra-only) but the schema
-   above supports it without changes.
+1. v1: `memory_store.py` + `build_memory_preamble` + write hook on session
+   end. No mastery-driven word selection yet — just remember and recall.
+   ~1.5 days incl. tests.
+2. v2: Spaced repetition drives word selection in `kids_teacher_flow`.
+   ~1 day.
+3. v3: Weekly affect summarizer (LLM-driven, cron or app-startup). ~0.5 day.
+4. v4 (optional): backup script.
 
-## Rollout sketch
-
-1. v1: Single GCS blob per child, semantic + last-3-sessions summary only.
-   No mastery yet. Memory preamble works. ~2 days.
-2. v2: Add mastery (Firestore subcollection or expand the blob), drive
-   spaced-repetition word selection. ~3 days.
-3. v3: Episodic JSONL + weekly summarizer. ~2 days.
-4. v4: Local cache + offline tolerance. Only if a real need emerges.
-
-Each step shipping with tests before moving on.
+Each step ships with tests before the next starts.

--- a/tasks/plan-persistent-memory.md
+++ b/tasks/plan-persistent-memory.md
@@ -2,178 +2,176 @@
 
 ## Context
 
-The kids-teacher flow on Reachy Mini should accumulate memory across sessions
-so the robot can:
+The kids-teacher flow on Reachy Mini should remember things about Myra
+across sessions — her brother's name, that she loves tigers, that her
+favorite colour is blue, the inside joke from yesterday. Today everything
+is in-process; nothing survives a restart.
 
-- Greet with continuity ("last time we worked on Telugu animals")
-- Run spaced repetition on words she's actually struggling with
-- Reference family members, favorites, and shared moments to feel personal
-- Resume narratives and inside jokes across days/weeks
+## The smallest thing that works
 
-Today every state lives in-process; nothing survives a restart.
+A single markdown file, parent- and child-curated, read into the model's
+system prompt at session start.
+
+```
+~/.myra/memory.md            # override via MYRA_MEMORY_FILE
+```
+
+Example contents:
+
+```markdown
+# Things to remember about Myra
+
+- Her little brother is Ahaan _(2026-03-12)_
+- She loves tigers and elephants _(2026-03-14)_
+- Favourite colour is blue _(2026-04-01)_
+- Inside joke: when she says "ba-ba-banana" we say "yes ma'am!" _(2026-04-12)_
+```
+
+That's it. No SQLite, no schema, no migrations, no episode log, no
+spaced-repetition machinery, no LLM-written recaps, no admin routes.
 
 ## Scope
 
-- **Reachy-only.** Web client is out of scope. The kids-teacher flow only runs
-  on the Pi-hosted robot.
-- **Single child per device.** One Reachy = one child. No multi-tenancy, no
-  `child_id` keying. If we ever need it, the schema below trivially extends.
-- **Kids-teacher flow only.** No reuse from the legacy lesson page or the
-  word-DB editor.
+- **Reachy-only, kids-teacher-only.** No web client, no other modes.
+- **Single child per device.** No keying.
+- **Memory ≠ mastery tracking.** Mastery (per-word success rate, spaced
+  repetition) is a separate feature, deferred. Mixing them was what
+  bloated the previous design.
 
-## Storage: local SQLite on the Pi
+## Why markdown over a DB
 
-Path: `~/.myra/memory.db` (override via `MYRA_MEMORY_DB_PATH`).
+- LLM-native: the file *is* the preamble. No `build_memory_preamble`
+  function, no formatting layer.
+- Parent-readable: `cat ~/.myra/memory.md` shows everything. Edit with
+  vim, delete a line, done. Best privacy UX possible.
+- Explicit consent: nothing is remembered without a human asking. This
+  is stronger than "log carefully and add a delete button".
+- ~40 lines of Python instead of ~400.
 
-Why SQLite over a JSON file:
-- Atomic writes — matters for crashes mid-session
-- Queries for spaced repetition (`WHERE next_due <= now ORDER BY next_due`)
-- Cheap schema migrations (`schema_version` table + idempotent `ALTER`s)
-- Single file, no daemon, `sqlite3` is in the stdlib
+## Integration
 
-What "persistent" actually buys us:
-- Reboots: ✓ (filesystem)
-- App reinstall / `pip install` / `git pull`: ✓ (data lives outside the
-  package)
-- `apt reinstall` of the Myra package: ✓ (DB is in `~/.myra/`, not in any
-  packaged dir)
-- SD-card reflash: ✗ — accept this, mitigate with an optional backup script
-  (`scripts/backup_memory.py` → copy to USB or email). Not required for v1.
+Existing wiring (already in the codebase):
 
-No cloud. No Firestore. No GCS. Memory never leaves the device, which is
-strictly better for a 4-year-old's data.
+- `src/kids_teacher_profile.py` reads `instructions.txt` into the
+  session payload's `instructions` field.
+- `src/kids_teacher_gemini_backend.py:140` passes that string into
+  `system_instruction` on the Gemini Live config.
 
-## Schema
+The memory feature is one concatenation:
 
-```sql
-CREATE TABLE schema_version (version INTEGER NOT NULL);
-
--- singleton row
-CREATE TABLE child (
-    id INTEGER PRIMARY KEY CHECK (id = 1),
-    name TEXT NOT NULL,
-    age INTEGER,
-    languages TEXT,                 -- JSON array
-    family TEXT,                    -- JSON: [{relation, name}, ...]
-    updated_at TEXT NOT NULL
-);
-
--- singleton row, refreshed by the weekly summarizer
-CREATE TABLE affect (
-    id INTEGER PRIMARY KEY CHECK (id = 1),
-    excites TEXT,                   -- JSON array
-    frustrates TEXT,                -- JSON array
-    jokes TEXT,                     -- JSON array
-    updated_at TEXT NOT NULL
-);
-
-CREATE TABLE mastery (
-    english TEXT NOT NULL,
-    language TEXT NOT NULL,         -- 'telugu' | 'assamese' | ...
-    attempts INTEGER NOT NULL DEFAULT 0,
-    successes INTEGER NOT NULL DEFAULT 0,
-    ease REAL NOT NULL DEFAULT 2.5, -- SM-2 style
-    last_seen TEXT,
-    next_due TEXT,
-    PRIMARY KEY (english, language)
-);
-CREATE INDEX idx_mastery_due ON mastery(next_due);
-
-CREATE TABLE episodes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    started_at TEXT NOT NULL,
-    ended_at TEXT NOT NULL,
-    words_covered TEXT,             -- JSON array of english words
-    mood TEXT,                      -- 'engaged'|'frustrated'|'tired'|...
-    summary TEXT                    -- one-line LLM-written recap
-);
-CREATE INDEX idx_episodes_ended_at ON episodes(ended_at);
+```python
+# in kids_teacher_profile.load_profile (or wherever instructions are assembled)
+memory_text = memory_file.read()  # "" if missing
+if memory_text:
+    instructions = f"{instructions}\n\n{memory_text}"
 ```
 
-`schema_version` starts at 1. Migrations: `memory_store.migrate()` runs on
-open and is idempotent.
+That's the entire v1 hot path.
 
-## Retrieval (hot path)
+## Writes
 
-Session start, in `kids_teacher_flow` (or backend init):
+The user's framing: memory is enriched only when the child or parent
+*asks* the robot to remember. Two phases:
 
-1. `child = memory_store.get_child()` — 1 row.
-2. `affect = memory_store.get_affect()` — 1 row.
-3. `due = memory_store.due_for_review(limit=5)` — words past `next_due`.
-4. `recap = memory_store.last_session_summary()` — newest `episodes.summary`.
-5. `build_memory_preamble(child, affect, due, recap) -> str` — hard cap
-   ~500 tokens, truncate `due` first if needed. Inject into the system
-   instructions for both `kids_teacher_backend` and
-   `kids_teacher_gemini_backend`.
+**v1 — read-only / parent-curated.**
+The parent edits `~/.myra/memory.md` directly. The robot reads it on
+every session start. Ships immediately, no tool-use plumbing needed.
+This is genuinely useful on its own: a parent can seed the file with
+"her brother is Ahaan, she loves tigers" and the robot will reference
+those naturally for weeks.
 
-Failure mode: any DB error → return empty preamble, log a warning, never
-block session start.
+**v2 — robot-writable via a `remember` tool.**
+Gemini Live supports function calling. We declare:
 
-## Writes (cold path)
+```python
+remember = FunctionDeclaration(
+    name="remember",
+    description=(
+        "Append a fact about the child to long-term memory. Call this "
+        "when the child or parent says 'remember that...' or shares "
+        "something the robot should know next time."
+    ),
+    parameters={"type": "object", "properties": {
+        "fact": {"type": "string", "description": "One-sentence fact."}
+    }, "required": ["fact"]},
+)
 
-End of session, in `kids_teacher_flow`:
+forget = FunctionDeclaration(
+    name="forget",
+    description="Remove a remembered fact by substring match.",
+    parameters={"type": "object", "properties": {
+        "fact_substring": {"type": "string"}
+    }, "required": ["fact_substring"]},
+)
+```
 
-1. For each word touched: `memory_store.record_attempt(word, language,
-   correct: bool)` — updates `attempts/successes`, recomputes `ease` and
-   `next_due` (SM-2-ish, kept simple: 1d / 3d / 7d / 14d ladder gated on
-   success).
-2. `memory_store.append_episode(started_at, ended_at, words_covered, mood,
-   summary)` — `summary` is a 1–2 sentence string the LLM produces at
-   session-end (cheap; we already have a turn log).
-3. Affect updates are *not* per-session. A weekly task (or app-startup
-   check) re-summarizes the last N episodes into the affect row. Out of
-   scope for v1 — start with manual updates via admin CLI.
+Tool body: `memory_file.append(fact)` / `memory_file.remove(substring)`.
+File operation is `open(... "a")` plus a `flock`; on remove, read-modify-
+rewrite with atomic rename.
 
-All writes are inside a single `with conn:` transaction so a crash leaves
-the DB consistent.
+Adds a small system-prompt nudge:
+
+> If the child or parent says "remember that…", call the `remember` tool.
+> At the end of an interesting session, you may call it once to record a
+> notable fact (e.g. a new favourite, a milestone).
+
+This requires adding tool-use plumbing to the Gemini Live backend, which
+doesn't exist yet — a bounded but real change. v1 ships without it.
 
 ## Files to add / touch
 
-- `src/memory_store.py` — new. Public API:
-  - `open(path: str | None = None) -> Connection`
-  - `migrate(conn)`
-  - `get_child(conn) -> dict | None`
-  - `set_child(conn, **fields)`
-  - `get_affect(conn) -> dict`
-  - `due_for_review(conn, limit=5) -> list[dict]`
-  - `record_attempt(conn, english, language, correct)`
-  - `append_episode(conn, **fields)`
-  - `last_session_summary(conn) -> str | None`
-- `src/memory_preamble.py` — pure function `build_memory_preamble(...)`
-  → `str`. Keeps prompt-shaping out of the store.
-- `src/kids_teacher_backend.py` + `kids_teacher_gemini_backend.py` —
-  inject preamble into system instructions. One call site each.
-- `src/kids_teacher_flow.py` — record attempts + append episode on
-  session end. Hooked into the existing end-of-session path.
-- `tests/test_memory_store.py` — DB lifecycle, migrations, SR scheduling,
-  due-for-review correctness, transaction rollback on error.
-- `tests/test_memory_preamble.py` — preamble shape, token cap, graceful
-  empties.
-- `tests/test_kids_teacher_flow.py` (extend) — assert attempts + episodes
-  written on session end.
-- `scripts/backup_memory.py` — *optional, deferred.* Copy DB to a path
-  (USB / scp). Only if SD-reflash recovery becomes a real need.
+v1:
+- `src/memory_file.py` — `read() -> str`, `append(fact: str) -> None`,
+  `remove(substring: str) -> bool`. Atomic write via tempfile+rename.
+  ~50 lines.
+- `src/kids_teacher_profile.py` — concat memory text into
+  `instructions`. ~3 lines.
+- `tests/test_memory_file.py` — read/append/remove, missing file,
+  concurrent write via lock.
+- `tests/test_kids_teacher_profile.py` (extend) — assert memory text
+  appears in the assembled instructions.
+
+v2 (only when v1 has shipped and is in use):
+- `src/kids_teacher_gemini_backend.py` — declare `remember` / `forget`
+  tools on the Live config; route `tool_call` events back to
+  `memory_file`. Existing event names already include `tool_call` /
+  `tool_call_cancellation` (see line 542) so the realtime layer will
+  surface them; we just have to handle them.
+- One nudge sentence in `instructions.txt`.
+- Tests: tool-call round-trip with a fake backend, file mutation
+  asserted.
+
+## Bounds and edge cases
+
+- **Size cap.** Soft cap at 4 KB. Beyond that, log a warning and ask
+  the parent to edit. (A 4-year-old's memory file isn't going to hit
+  this for a long time.)
+- **Concurrency.** Only one robot process runs at a time on Reachy, but
+  use `fcntl.flock` on append for safety.
+- **Atomicity on remove.** Read into memory, filter, write to
+  `memory.md.tmp`, `os.replace` over the original.
+- **Missing file.** Treat as empty. Don't auto-create until the first
+  successful write.
+- **Reinstall survival.** Lives at `~/.myra/memory.md` — outside any
+  package dir, so `pip install` / `git pull` / `apt reinstall` leave
+  it alone. SD-card reflash wipes it; mitigate later only if needed.
 
 ## Open questions
 
-1. **DB path.** `~/.myra/memory.db` follows XDG-ish convention; alternative
-   is `/var/lib/myra/memory.db` if we want it survivable across user
-   account changes. Recommend `~/.myra/` for now (simpler perms).
-2. **Mood detection.** `episodes.mood` is easy if the LLM tags it at
-   session-end; punt to a follow-up if that's not free.
-3. **Spaced-repetition aggressiveness.** Start with a fixed 1d / 3d / 7d /
-   14d ladder; tune later if Myra's retention curve says otherwise.
-4. **Backup story.** Defer until reflash actually loses something the
-   parent cares about.
+1. **System-prompt heading.** Should the file's contents be wrapped in
+   a `## Things to remember about Myra` heading, or just appended raw?
+   I'd default to appending raw since the file already has its own
+   `# Things to remember about Myra` heading at the top.
+2. **Date stamps in the file.** Useful for the LLM ("we said this
+   recently"); also helps the parent prune. Default: yes, append
+   `_(YYYY-MM-DD)_` on each new line.
+3. **Mastery tracking.** Out of scope here. If we want SR later, add
+   a tiny `mastery` SQLite table (or even another markdown file)
+   purely for that — don't conflate it with memory.
 
 ## Rollout
 
-1. v1: `memory_store.py` + `build_memory_preamble` + write hook on session
-   end. No mastery-driven word selection yet — just remember and recall.
-   ~1.5 days incl. tests.
-2. v2: Spaced repetition drives word selection in `kids_teacher_flow`.
-   ~1 day.
-3. v3: Weekly affect summarizer (LLM-driven, cron or app-startup). ~0.5 day.
-4. v4 (optional): backup script.
-
-Each step ships with tests before the next starts.
+1. v1: read-only, parent-curated. ~half a day with tests.
+2. Use it for a couple of weeks. See whether the parent-edits-the-file
+   loop is actually annoying enough to justify v2.
+3. v2 only if v1 surfaces a real friction point.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -111,45 +111,42 @@ Design doc: [tasks/face-recognition-design.md](face-recognition-design.md)
 ### Persistent Memory ("Robot That Remembers Myra")
 Design doc: [tasks/plan-persistent-memory.md](plan-persistent-memory.md)
 
-Goal: the robot accumulates memory of the child across sessions, devices, and
-reinstalls — so it can greet with continuity, run spaced repetition on words
-she's actually struggling with, and reference family/favorites/inside jokes.
+Goal: kids-teacher flow on Reachy Mini accumulates memory across sessions so
+the robot can greet with continuity, run spaced repetition on words she's
+actually struggling with, and reference family/favorites/inside jokes.
+
+Scope: **Reachy-only, kids-teacher only, single child per device.** No web
+client, no multi-tenancy, no cloud.
 
 Key design choices (see plan doc for rationale):
-- **Child-keyed, not device-keyed.** Primary key is a parent-set `child_id`;
-  device IDs are incidental. Cloud is the source of truth so a reinstall just
-  re-fetches.
-- **Four memory kinds**, separated by access pattern: semantic (facts),
-  procedural (per-word mastery), episodic (session log), affective (likes/
-  frustrations).
-- **Firestore for the hot path, GCS for cold episode blobs** — but v1 may use
-  a single GCS JSON blob per child to avoid the new Firestore dep.
-- **LLM injection via a ≤500-token preamble** built at session start; never
-  dump full history into the model context.
-- **Privacy: admin-only access, cascade-delete path, no raw audio in memory.**
+- **Local SQLite on the Pi** at `~/.myra/memory.db` (override via
+  `MYRA_MEMORY_DB_PATH`). Survives reboots and app reinstalls; an SD-card
+  reflash wipes it (acceptable; backup script deferred to v4).
+- **Privacy by construction:** child data never leaves the device.
+- **Four tables** matching access patterns: `child` (semantic),
+  `affect` (likes/frustrations), `mastery` (per-word SR state),
+  `episodes` (session log).
+- **LLM injection via a ≤500-token preamble** at session start; never dump
+  full history into model context. Empty preamble on any DB error — never
+  block the session.
 
 Checklist (rollout phases — ship tests with each):
 
-- [ ] `High` Resolve open questions in plan doc §"Open questions" (Firestore
-  vs. blob-only, web identity model, offline cache scope) before any coding
-- [ ] `High` v1: `src/memory_store.py` — GCS-backed semantic + last-3-sessions
-  summary, keyed on `child_id`. Read-on-start, write-on-session-end. Tests
-  with a fake GCS client.
-- [ ] `High` v1: `build_memory_preamble(child_id) -> str` consumed by both
-  `kids_teacher_backend` and `kids_teacher_gemini_backend`. Hard ≤500-token
-  cap. Falls back to empty string on fetch failure (never blocks start).
-- [ ] `High` v1: admin routes — `GET`/`DELETE`/`POST redact` under
-  `/admin/memory/{child_id}`. Reuse existing admin auth.
-- [ ] `Medium` v2: per-word mastery (attempts/successes/ease/last_seen) +
-  spaced-repetition word selection in `kids_teacher_flow`
-- [ ] `Medium` v3: episodic JSONL append-only blobs + weekly summarizer that
-  refreshes the affective doc and trims episodes older than 1 year
-- [ ] `Medium` Schema versioning + migration path (`schema_version: 1` on
-  every doc, migration helper invoked on read)
-- [ ] `Low` v4: local SQLite cache on robot for offline tolerance — only if
-  a real offline scenario surfaces in practice
-- [ ] `Low` Multi-child households (schema already supports it; deferred
-  until needed)
+- [ ] `High` v1: `src/memory_store.py` — SQLite open + migrate + CRUD for
+  `child`, `affect`, `mastery`, `episodes`. Schema-versioned. Tests cover
+  lifecycle, migrations, transaction rollback.
+- [ ] `High` v1: `src/memory_preamble.py::build_memory_preamble(...)` — pure
+  function, hard ≤500-token cap, truncates `due` words first. Consumed by
+  both `kids_teacher_backend` and `kids_teacher_gemini_backend`.
+- [ ] `High` v1: Wire end-of-session writes in `kids_teacher_flow` —
+  `record_attempt` per word + `append_episode` with LLM-written 1–2 sentence
+  summary. Single transaction.
+- [ ] `Medium` v2: Spaced-repetition word selection (1d/3d/7d/14d ladder,
+  SM-2-ish) drives next-word choice in `kids_teacher_flow`.
+- [ ] `Medium` v3: Weekly affect summarizer — LLM re-summarizes last N
+  episodes into the `affect` row (cron or app-startup).
+- [ ] `Low` v4: `scripts/backup_memory.py` — only if SD-card reflash recovery
+  becomes a real need.
 
 ### Language Lesson Polish
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -108,6 +108,49 @@ Design doc: [tasks/face-recognition-design.md](face-recognition-design.md)
 - [ ] Run full test suite — confirm all tests pass
 - [ ] On-Pi verification — enroll, verify, run full session
 
+### Persistent Memory ("Robot That Remembers Myra")
+Design doc: [tasks/plan-persistent-memory.md](plan-persistent-memory.md)
+
+Goal: the robot accumulates memory of the child across sessions, devices, and
+reinstalls — so it can greet with continuity, run spaced repetition on words
+she's actually struggling with, and reference family/favorites/inside jokes.
+
+Key design choices (see plan doc for rationale):
+- **Child-keyed, not device-keyed.** Primary key is a parent-set `child_id`;
+  device IDs are incidental. Cloud is the source of truth so a reinstall just
+  re-fetches.
+- **Four memory kinds**, separated by access pattern: semantic (facts),
+  procedural (per-word mastery), episodic (session log), affective (likes/
+  frustrations).
+- **Firestore for the hot path, GCS for cold episode blobs** — but v1 may use
+  a single GCS JSON blob per child to avoid the new Firestore dep.
+- **LLM injection via a ≤500-token preamble** built at session start; never
+  dump full history into the model context.
+- **Privacy: admin-only access, cascade-delete path, no raw audio in memory.**
+
+Checklist (rollout phases — ship tests with each):
+
+- [ ] `High` Resolve open questions in plan doc §"Open questions" (Firestore
+  vs. blob-only, web identity model, offline cache scope) before any coding
+- [ ] `High` v1: `src/memory_store.py` — GCS-backed semantic + last-3-sessions
+  summary, keyed on `child_id`. Read-on-start, write-on-session-end. Tests
+  with a fake GCS client.
+- [ ] `High` v1: `build_memory_preamble(child_id) -> str` consumed by both
+  `kids_teacher_backend` and `kids_teacher_gemini_backend`. Hard ≤500-token
+  cap. Falls back to empty string on fetch failure (never blocks start).
+- [ ] `High` v1: admin routes — `GET`/`DELETE`/`POST redact` under
+  `/admin/memory/{child_id}`. Reuse existing admin auth.
+- [ ] `Medium` v2: per-word mastery (attempts/successes/ease/last_seen) +
+  spaced-repetition word selection in `kids_teacher_flow`
+- [ ] `Medium` v3: episodic JSONL append-only blobs + weekly summarizer that
+  refreshes the affective doc and trims episodes older than 1 year
+- [ ] `Medium` Schema versioning + migration path (`schema_version: 1` on
+  every doc, migration helper invoked on read)
+- [ ] `Low` v4: local SQLite cache on robot for offline tolerance — only if
+  a real offline scenario surfaces in practice
+- [ ] `Low` Multi-child households (schema already supports it; deferred
+  until needed)
+
 ### Language Lesson Polish
 
 - [ ] Add celebratory jingles

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -111,42 +111,42 @@ Design doc: [tasks/face-recognition-design.md](face-recognition-design.md)
 ### Persistent Memory ("Robot That Remembers Myra")
 Design doc: [tasks/plan-persistent-memory.md](plan-persistent-memory.md)
 
-Goal: kids-teacher flow on Reachy Mini accumulates memory across sessions so
-the robot can greet with continuity, run spaced repetition on words she's
-actually struggling with, and reference family/favorites/inside jokes.
+Goal: kids-teacher flow on Reachy Mini remembers things about Myra across
+sessions — her brother's name, that she loves tigers, the inside joke from
+yesterday.
 
-Scope: **Reachy-only, kids-teacher only, single child per device.** No web
-client, no multi-tenancy, no cloud.
+Scope: **Reachy-only, kids-teacher only, single child per device.** Memory
+is *only* enriched when a human asks (parent edits the file, or — in v2 —
+the child/parent says "remember that…" and the LLM calls a tool). Memory
+is **not** the same as mastery tracking; spaced repetition is a separate
+deferred feature.
 
-Key design choices (see plan doc for rationale):
-- **Local SQLite on the Pi** at `~/.myra/memory.db` (override via
-  `MYRA_MEMORY_DB_PATH`). Survives reboots and app reinstalls; an SD-card
-  reflash wipes it (acceptable; backup script deferred to v4).
-- **Privacy by construction:** child data never leaves the device.
-- **Four tables** matching access patterns: `child` (semantic),
-  `affect` (likes/frustrations), `mastery` (per-word SR state),
-  `episodes` (session log).
-- **LLM injection via a ≤500-token preamble** at session start; never dump
-  full history into model context. Empty preamble on any DB error — never
-  block the session.
+Key design choices (see plan doc):
+- **One markdown file** at `~/.myra/memory.md` (override via
+  `MYRA_MEMORY_FILE`). The file *is* the system-prompt preamble.
+- **Parent-readable, parent-editable.** `cat`/`vim` covers privacy + audit
+  + delete; no admin routes needed.
+- **No DB, no schema, no episode log, no summarizer, no cron.**
+- **Integration is one concat** into the existing `instructions` string
+  built by `kids_teacher_profile.py` and consumed at
+  `kids_teacher_gemini_backend.py:140`.
 
-Checklist (rollout phases — ship tests with each):
+Checklist:
 
-- [ ] `High` v1: `src/memory_store.py` — SQLite open + migrate + CRUD for
-  `child`, `affect`, `mastery`, `episodes`. Schema-versioned. Tests cover
-  lifecycle, migrations, transaction rollback.
-- [ ] `High` v1: `src/memory_preamble.py::build_memory_preamble(...)` — pure
-  function, hard ≤500-token cap, truncates `due` words first. Consumed by
-  both `kids_teacher_backend` and `kids_teacher_gemini_backend`.
-- [ ] `High` v1: Wire end-of-session writes in `kids_teacher_flow` —
-  `record_attempt` per word + `append_episode` with LLM-written 1–2 sentence
-  summary. Single transaction.
-- [ ] `Medium` v2: Spaced-repetition word selection (1d/3d/7d/14d ladder,
-  SM-2-ish) drives next-word choice in `kids_teacher_flow`.
-- [ ] `Medium` v3: Weekly affect summarizer — LLM re-summarizes last N
-  episodes into the `affect` row (cron or app-startup).
-- [ ] `Low` v4: `scripts/backup_memory.py` — only if SD-card reflash recovery
-  becomes a real need.
+- [ ] `High` v1: `src/memory_file.py` — `read()`, `append(fact)`,
+  `remove(substring)`. Atomic write (tempfile + `os.replace`), `flock` on
+  append, missing-file → empty. ~50 lines + tests.
+- [ ] `High` v1: Concat memory text into `instructions` in
+  `kids_teacher_profile.py`. Extend `tests/test_kids_teacher_profile.py`
+  to assert it shows up in the assembled session payload.
+- [ ] `High` v1: Soft 4 KB cap with a warning log when exceeded (parent
+  prunes manually).
+- [ ] `Medium` v2: Add Gemini Live tool-use plumbing + declare `remember`
+  and `forget` function tools so the child/parent can say "remember
+  that…" and the robot writes it. Route `tool_call` events back to
+  `memory_file`. One-line nudge in `instructions.txt`. **Only after v1
+  has been used for a couple of weeks and parent-editing is genuinely
+  friction.**
 
 ### Language Lesson Polish
 


### PR DESCRIPTION
Captures the design for a robot that remembers Myra across sessions,
devices, and reinstalls. Memory is child-keyed (not device-keyed) and
backed by cloud storage so reinstalls just re-fetch. Splits memory into
semantic / procedural / episodic / affective categories with a phased
rollout (GCS-blob v1, Firestore mastery v2, episodic + summarizer v3,
local cache v4 only if needed).

https://claude.ai/code/session_01BM4Wi7VAb5e5bepBeXxBdh