### PR TITLE
motion-director: ship Phases 0-3 + bridge wiring (face tracking)

### DIFF
--- a/REACHY_PI_SETUP.md
+++ b/REACHY_PI_SETUP.md
@@ -158,6 +158,27 @@ Variables you should know:
 - `GCP_PROJECT`
   Needed only if you want `/api/translate` to fall back to Google Translate for unknown words.
 
+### Motion director (kids-teacher mode only)
+
+The robot's body language is driven by a three-layer additive motion stack
+(audio-reactive wobble, LLM-chosen gestures, face-tracking offsets). Layer
+selection is operator-controlled:
+
+- `KIDS_TEACHER_MOTION_LAYERS=full|none|<csv>`
+  Default: `full` (all layers on). Use `none` to fall back to the legacy
+  `speak`/`listen`/`idle` state machine — useful while debugging hardware.
+  CSV subset names: `wobble` (L1), `gestures` (L2), `tracking` (L3).
+  Example: `KIDS_TEACHER_MOTION_LAYERS=wobble,tracking` runs everything
+  except LLM-driven gesture tools. The CLI flag `--motion-layers` overrides
+  this var when both are set.
+- `KIDS_TEACHER_GAZE_FOLLOW_ENABLED=true|false`
+  Hard-kill switch for L3 (face tracking). Falsey here disables L3 even if
+  `KIDS_TEACHER_MOTION_LAYERS` would otherwise enable it. Default: `true`.
+- `KIDS_TEACHER_GAZE_HZ` (default `3.0`) and `KIDS_TEACHER_GAZE_DEAD_ZONE`
+  (default `0.05`) tune the face tracker itself.
+- `KIDS_TEACHER_CHILD_NAME` makes L3 prefer the enrolled child's face over
+  the closest visible person. Unset = closest face wins.
+
 Credentials:
 
 - For Google Translate fallback and GCS sync from the Pi, the process must have Google application default credentials or a service account configured.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Child speech ─▶ mic pump ─▶ RealtimeBackend (OpenAI | Gemini) ─▶ Han
 - `src/kids_review_store.py` — local-first transcript + raw-audio retention, optional GCS sync
 - `src/kids_teacher_flow.py` — orchestrator; wires safety + review + hooks around the handler
 - `src/kids_teacher_robot_bridge.py` — robot audio bridge (playback thread + mic pump)
+- `src/motion/` — three-layer motion director (audio wobble + LLM-chosen gestures + face-tracking offsets). Toggle with `KIDS_TEACHER_MOTION_LAYERS=full|none|<csv>` (or `--motion-layers`); see `REACHY_PI_SETUP.md` for layer details.
 - `profiles/kids_teacher/{instructions,tools,voice}.txt` — the locked persona content
 
 ### Prerequisites

--- a/src/kids_teacher_backend.py
+++ b/src/kids_teacher_backend.py
@@ -123,6 +123,8 @@ def build_session_payload(
     config: KidsTeacherSessionConfig,
     *,
     modalities: tuple[str, ...] = ("audio", "text"),
+    additional_tools: Optional[list[dict]] = None,
+    additional_instructions: Optional[str] = None,
 ) -> dict:
     """Build the JSON-serializable ``session.update`` payload.
 
@@ -131,9 +133,14 @@ def build_session_payload(
     internal tools (for example Gemini's persistent-memory helper)
     during provider-specific config translation. V1 uses server-side VAD
     and OpenAI's ``gpt-4o-mini-transcribe`` for input transcripts.
+
+    ``additional_tools`` lets callers inject fully-specified tool dicts
+    (e.g. the motion-director gesture tools) alongside the profile
+    allowlist. They are appended in order; profile-allowlisted names take
+    precedence if a name collides.
     """
     profile = config.profile
-    tools = [
+    tools: list[dict] = [
         # Tool-spec lookup is deliberately NOT part of V1 — this is a
         # minimal stub so the backend can wire up allowlisted names.
         # Intern 2 / integration phase will replace this with real tool
@@ -141,8 +148,17 @@ def build_session_payload(
         {"type": "function", "name": name}
         for name in profile.allowed_tools
     ]
+    if additional_tools:
+        existing_names = {t.get("name") for t in tools}
+        for spec in additional_tools:
+            if spec.get("name") in existing_names:
+                continue
+            tools.append(spec)
+    instructions = profile.instructions
+    if additional_instructions:
+        instructions = f"{instructions}\n\n{additional_instructions.strip()}"
     return {
-        "instructions": profile.instructions,
+        "instructions": instructions,
         "voice": profile.voice,
         "modalities": list(modalities),
         "input_audio_transcription": {"model": _INPUT_TRANSCRIPTION_MODEL},
@@ -169,6 +185,15 @@ class RealtimeBackend(Protocol):
 
     async def cancel_response(self) -> None: ...
 
+    async def send_tool_response(self, call_id: str, output: str) -> None:
+        """Acknowledge a function tool call back to the model.
+
+        ``output`` is a free-form string (typically JSON) the model can read
+        as the function result. Backends that don't support tool calls may
+        leave this as a no-op.
+        """
+        ...
+
     async def close(self) -> None: ...
 
     def events(self) -> AsyncIterator[dict]:
@@ -183,6 +208,7 @@ class RealtimeBackend(Protocol):
           * ``assistant_transcript.delta`` ``{"text": str}``
           * ``assistant_transcript.final`` ``{"text": str, "language": Optional[str]}``
           * ``audio.chunk``              ``{"audio": bytes}`` (raw PCM16)
+          * ``tool.call``                ``{"call_id": str, "name": str, "arguments": str}`` (JSON string)
           * ``response.done``            ``{}``
           * ``error``                    ``{"message": str}``
         """
@@ -346,6 +372,16 @@ class OpenAIRealtimeBackend:
                 "type": "audio.chunk",
                 "audio": _decode_audio_delta(_field("delta", "")),
             }
+        if raw_type == "response.function_call_arguments.done":
+            # Function tool calls land as one event per call. ``arguments``
+            # is a JSON string the SDK leaves un-parsed; pass it through so
+            # the bridge can decode at dispatch time.
+            return {
+                "type": "tool.call",
+                "call_id": _field("call_id", "") or "",
+                "name": _field("name", "") or "",
+                "arguments": _field("arguments", "") or "",
+            }
         if raw_type == "response.done":
             return {"type": "response.done"}
         if raw_type == "error":
@@ -401,6 +437,29 @@ class OpenAIRealtimeBackend:
             await self._connection.response.cancel()  # type: ignore[attr-defined]
         except Exception as exc:  # pragma: no cover - integration path
             logger.warning("[kids_teacher_backend] cancel_response failed: %s", exc)
+
+    async def send_tool_response(self, call_id: str, output: str) -> None:
+        """Send a ``function_call_output`` so the model can continue.
+
+        OpenAI Realtime expects each function call to be acknowledged with
+        a conversation item of type ``function_call_output`` carrying the
+        same ``call_id`` and a string ``output``. Without this the model
+        can stall waiting for the result.
+        """
+        if self._connection is None or not call_id:
+            return
+        try:
+            await self._connection.conversation.item.create(  # type: ignore[attr-defined]
+                item={
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": output,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - integration path
+            logger.warning(
+                "[kids_teacher_backend] send_tool_response failed: %s", exc
+            )
 
     async def close(self) -> None:
         if self._closed:

--- a/src/kids_teacher_fakes.py
+++ b/src/kids_teacher_fakes.py
@@ -22,7 +22,8 @@ class FakeRealtimeBackend:
 
     Pass a list of events to emit in order. Tests can also push additional
     events mid-run via :meth:`push_event`. All side-effect calls
-    (send_audio, send_text, cancel_response, close) are recorded.
+    (send_audio, send_text, cancel_response, send_tool_response, close)
+    are recorded.
     """
 
     def __init__(
@@ -44,6 +45,7 @@ class FakeRealtimeBackend:
         self.text_messages: List[str] = []
         self.cancel_calls: int = 0
         self.close_calls: int = 0
+        self.tool_responses: List[tuple] = []
 
     async def connect(self, session_payload: dict) -> None:
         self.connect_calls.append(session_payload)
@@ -65,6 +67,9 @@ class FakeRealtimeBackend:
 
     async def cancel_response(self) -> None:
         self.cancel_calls += 1
+
+    async def send_tool_response(self, call_id: str, output: str) -> None:
+        self.tool_responses.append((call_id, output))
 
     async def close(self) -> None:
         self.close_calls += 1

--- a/src/kids_teacher_flow.py
+++ b/src/kids_teacher_flow.py
@@ -185,13 +185,19 @@ def _default_recovery_cue(robot_controller: object) -> None:
         )
 
 
-def build_robot_hooks(robot_controller: object) -> KidsTeacherRuntimeHooks:
+def build_robot_hooks(
+    robot_controller: object, *, motion_stack: object = None
+) -> KidsTeacherRuntimeHooks:
     """Build the real robot audio bridge hooks for a running session.
 
     Imports :mod:`kids_teacher_robot_bridge` lazily so this module stays
     importable when the robot SDK (or its optional audio deps) is missing.
     Callers are responsible for ``.start()``/``.stop()`` on the returned
     hooks — the flow wires that lifecycle around ``run_kids_teacher_session``.
+
+    ``motion_stack`` is the optional motion-director orchestrator. When
+    provided, the bridge routes state and audio through it; when ``None``,
+    the legacy speak/listen/idle path runs unchanged.
     """
     from kids_teacher_robot_bridge import KidsTeacherRobotHooks
 
@@ -199,6 +205,7 @@ def build_robot_hooks(robot_controller: object) -> KidsTeacherRuntimeHooks:
         robot_controller=robot_controller,
         playback_speed=_resolve_playback_speed(),
         recovery_cue=_default_recovery_cue,
+        motion_stack=motion_stack,
     )
 
 

--- a/src/kids_teacher_realtime.py
+++ b/src/kids_teacher_realtime.py
@@ -86,7 +86,13 @@ class KidsTeacherRealtimeHandler:
         """Connect the backend and move the session into LISTENING state."""
         if self._started:
             return
-        payload = build_session_payload(self._config)
+        extra_tools = self._collect_additional_tool_specs()
+        extra_instructions = self._collect_additional_instructions()
+        payload = build_session_payload(
+            self._config,
+            additional_tools=extra_tools,
+            additional_instructions=extra_instructions,
+        )
         try:
             await self._backend.connect(payload)
         except Exception as exc:
@@ -196,9 +202,9 @@ class KidsTeacherRealtimeHandler:
         if event_type == "input.speech_started":
             await self._on_speech_started()
         elif event_type == "input.speech_stopped":
-            # VAD end-of-speech signal — no action needed; the final
-            # transcript event drives downstream behavior.
-            pass
+            # VAD end-of-speech signal — no action needed for the handler;
+            # forward the edge so motion-director hooks can update gaze gain.
+            self._notify_hook("on_speech_stopped")
         elif event_type == "input_transcript.delta":
             await self._on_input_delta(event)
         elif event_type == "input_transcript.final":
@@ -209,6 +215,8 @@ class KidsTeacherRealtimeHandler:
             self._on_assistant_final(event)
         elif event_type == "audio.chunk":
             self._on_audio_chunk(event)
+        elif event_type == "tool.call":
+            await self._on_tool_call(event)
         elif event_type == "response.done":
             self._on_response_done()
         elif event_type == "session.reconnecting":
@@ -224,6 +232,7 @@ class KidsTeacherRealtimeHandler:
         """Earliest barge-in signal from server-side VAD."""
         if self._assistant_active:
             await self._cancel_active_response(reason="input.speech_started")
+        self._notify_hook("on_speech_started")
 
     async def _on_input_delta(self, event: dict) -> None:
         text = event.get("text", "") or ""
@@ -287,6 +296,39 @@ class KidsTeacherRealtimeHandler:
             self._hooks.start_assistant_playback(audio)
         except Exception as exc:
             logger.warning("[kids_teacher_realtime] playback hook raised: %s", exc)
+
+    async def _on_tool_call(self, event: dict) -> None:
+        """Route a function tool call to the runtime hook and ack the model.
+
+        The hook runs synchronously on the event loop; gesture dispatch is
+        non-blocking (just a deque + composer.play_clip). If the hook
+        returns a string we ship it back as ``function_call_output`` so
+        the model can continue its turn without stalling.
+        """
+        handler = getattr(self._hooks, "handle_tool_call", None)
+        if handler is None:
+            logger.debug(
+                "[kids_teacher_realtime] tool.call ignored: hooks expose no handle_tool_call"
+            )
+            return
+        call_id = str(event.get("call_id") or "")
+        name = str(event.get("name") or "")
+        arguments = event.get("arguments", "")
+        if not isinstance(arguments, str):
+            arguments = ""
+        try:
+            output = handler(call_id, name, arguments)
+        except Exception as exc:
+            logger.warning("[kids_teacher_realtime] handle_tool_call raised: %s", exc)
+            return
+        if not call_id or output is None:
+            return
+        try:
+            await self._backend.send_tool_response(call_id, output)
+        except Exception as exc:
+            logger.warning(
+                "[kids_teacher_realtime] send_tool_response raised: %s", exc
+            )
 
     def _on_response_done(self) -> None:
         logger.info("[kids_teacher_realtime] response.done — turn complete")
@@ -404,6 +446,54 @@ class KidsTeacherRealtimeHandler:
         except Exception as exc:
             logger.warning(
                 "[kids_teacher_realtime] publish_transcript raised: %s", exc
+            )
+
+    def _collect_additional_tool_specs(self) -> Optional[list]:
+        """Collect optional extra tool specs from the hooks (e.g. motion-director).
+
+        Hooks that don't provide tools simply omit the method; we fall back
+        to ``None`` so ``build_session_payload`` keeps the existing behaviour.
+        """
+        method = getattr(self._hooks, "additional_tool_specs", None)
+        if method is None:
+            return None
+        try:
+            specs = method()
+        except Exception as exc:
+            logger.warning(
+                "[kids_teacher_realtime] additional_tool_specs raised: %s", exc
+            )
+            return None
+        if not specs:
+            return None
+        return list(specs)
+
+    def _collect_additional_instructions(self) -> Optional[str]:
+        """Optional system-prompt extension provided by the hooks layer."""
+        method = getattr(self._hooks, "additional_instructions", None)
+        if method is None:
+            return None
+        try:
+            text = method()
+        except Exception as exc:
+            logger.warning(
+                "[kids_teacher_realtime] additional_instructions raised: %s", exc
+            )
+            return None
+        if not text:
+            return None
+        return str(text)
+
+    def _notify_hook(self, method_name: str) -> None:
+        """Call an optional zero-arg hook method, swallowing any exception."""
+        method = getattr(self._hooks, method_name, None)
+        if method is None:
+            return
+        try:
+            method()
+        except Exception as exc:
+            logger.warning(
+                "[kids_teacher_realtime] %s raised: %s", method_name, exc
             )
 
     def _publish_status(

--- a/src/kids_teacher_robot_bridge.py
+++ b/src/kids_teacher_robot_bridge.py
@@ -79,6 +79,7 @@ class KidsTeacherRobotHooks:
         play_chunk: Optional[Callable[[Any, bytes, int], None]] = None,
         playback_speed: float = 1.0,
         recovery_cue: Optional[Callable[[Any], None]] = None,
+        motion_stack: Optional[Any] = None,
     ) -> None:
         """Create a hook implementation bound to ``robot_controller``.
 
@@ -109,10 +110,17 @@ class KidsTeacherRobotHooks:
                 gap instead of dead air. Called on a short-lived helper
                 thread so a slow TTS fetch can't block the realtime
                 handler. Tests leave this ``None`` (cue is skipped).
+            motion_stack: Optional :class:`motion.stack.MotionStack`. When
+                present, the bridge routes state and audio through the
+                stack instead of the legacy ``robot.speak/listen/idle``
+                methods — the composer becomes the sole pose driver. Leave
+                ``None`` to preserve the pre-motion-director behaviour
+                (the kill switch).
         """
         self._robot = robot_controller
         self._sample_rate = sample_rate
         self._log = logger_override or logger
+        self._motion_stack = motion_stack
         if play_chunk is not None:
             self._play_chunk = play_chunk
         else:
@@ -160,6 +168,13 @@ class KidsTeacherRobotHooks:
                 self._log.warning(
                     "[kids_teacher_robot_bridge] prime_speaker raised: %s", exc
                 )
+        if self._motion_stack is not None:
+            try:
+                self._motion_stack.start()
+            except Exception as exc:
+                self._log.warning(
+                    "[kids_teacher_robot_bridge] motion_stack.start raised: %s", exc
+                )
         self._thread = threading.Thread(
             target=self._playback_loop,
             name="kids-teacher-robot-playback",
@@ -184,6 +199,13 @@ class KidsTeacherRobotHooks:
                     timeout,
                 )
         self._thread = None
+        if self._motion_stack is not None:
+            try:
+                self._motion_stack.stop(timeout=min(timeout, 1.0))
+            except Exception as exc:
+                self._log.warning(
+                    "[kids_teacher_robot_bridge] motion_stack.stop raised: %s", exc
+                )
 
     # ------------------------------------------------------------------
     # KidsTeacherRuntimeHooks protocol
@@ -197,13 +219,27 @@ class KidsTeacherRobotHooks:
             self._queue.append(audio_chunk)
         self._chunk_available.set()
 
+        # Feed the L1 wobble layer every chunk — it modulates a smoothed
+        # loudness envelope and is cheap to call.
+        if self._motion_stack is not None:
+            try:
+                self._motion_stack.feed_assistant_audio(audio_chunk)
+            except Exception as exc:
+                self._log.debug(
+                    "[kids_teacher_robot_bridge] feed_assistant_audio raised: %s",
+                    exc,
+                )
+
         # Only trigger the speak animation on the FIRST chunk of a turn.
         # Subsequent chunks within the same turn should not re-kick the
         # animation — otherwise every delta restarts the nod loop.
         with self._speaking_lock:
             if not self._speaking_active:
                 self._speaking_active = True
-                self._safe_call("speak")
+                if self._motion_stack is not None:
+                    self._motion_stack_call("enter_assistant_speech")
+                else:
+                    self._safe_call("speak")
 
     def stop_assistant_playback(self) -> None:
         """Flush queued audio and restore the listening animation.
@@ -220,7 +256,10 @@ class KidsTeacherRobotHooks:
         with self._speaking_lock:
             self._speaking_active = False
         self._safe_call("flush_output_audio")
-        self._safe_call("listen")
+        if self._motion_stack is not None:
+            self._motion_stack_call("exit_assistant_speech")
+        else:
+            self._safe_call("listen")
 
     def publish_transcript(self, event: KidsTranscriptEvent) -> None:
         """Log transcript events for robot-side observability only."""
@@ -237,26 +276,38 @@ class KidsTeacherRobotHooks:
         """Map session status transitions to robot animations."""
         status = event.status
         if status == SessionStatus.LISTENING:
-            self._safe_call("listen")
+            if self._motion_stack is not None:
+                self._motion_stack_call("exit_assistant_speech")
+            else:
+                self._safe_call("listen")
         elif status == SessionStatus.SPEAKING:
             # Speaking is normally triggered by the first audio chunk.
             # Calling again here is a safe idempotent backstop.
             with self._speaking_lock:
                 if not self._speaking_active:
                     self._speaking_active = True
-                    self._safe_call("speak")
+                    if self._motion_stack is not None:
+                        self._motion_stack_call("enter_assistant_speech")
+                    else:
+                        self._safe_call("speak")
         elif status == SessionStatus.THINKING:
             # RobotController has no dedicated thinking pose; no-op keeps
             # the listen/speak animations intact during the pause.
             return
         elif status == SessionStatus.IDLE:
-            self._safe_call("idle")
+            if self._motion_stack is not None:
+                self._motion_stack_call("set_idle")
+            else:
+                self._safe_call("idle")
         elif status == SessionStatus.ENDED:
             self._log.info(
                 "[kids_teacher_robot_bridge] session ended: %s",
                 event.detail or "goodbye",
             )
-            self._safe_call("idle")
+            if self._motion_stack is not None:
+                self._motion_stack_call("set_idle")
+            else:
+                self._safe_call("idle")
         elif status == SessionStatus.RECONNECTING:
             self._log.info(
                 "[kids_teacher_robot_bridge] session reconnecting: %s",
@@ -270,14 +321,20 @@ class KidsTeacherRobotHooks:
             with self._speaking_lock:
                 self._speaking_active = False
             self._safe_call("flush_output_audio")
-            self._safe_call("listen")
+            if self._motion_stack is not None:
+                self._motion_stack_call("exit_assistant_speech")
+            else:
+                self._safe_call("listen")
             self._fire_recovery_cue()
         elif status == SessionStatus.ERROR:
             self._log.warning(
                 "[kids_teacher_robot_bridge] session error: %s",
                 event.detail or "unknown",
             )
-            self._safe_call("idle")
+            if self._motion_stack is not None:
+                self._motion_stack_call("set_idle")
+            else:
+                self._safe_call("idle")
 
     def persist_artifact(
         self,
@@ -286,6 +343,67 @@ class KidsTeacherRobotHooks:
     ) -> None:
         """No-op. The flow's review-store wrapper handles persistence."""
         return None
+
+    def handle_tool_call(
+        self, call_id: str, name: str, arguments: str
+    ) -> Optional[str]:
+        """Forward a function tool call to the motion stack.
+
+        When no motion stack is configured we ignore the call and return
+        ``None`` so the realtime handler skips the ack. The stack itself
+        validates the tool name + arguments and returns a JSON ack string.
+        """
+        if self._motion_stack is None:
+            return None
+        try:
+            return self._motion_stack.handle_tool_call(call_id, name, arguments)
+        except Exception as exc:
+            self._log.warning(
+                "[kids_teacher_robot_bridge] handle_tool_call raised: %s", exc
+            )
+            return None
+
+    def on_speech_started(self) -> None:
+        """Forward the VAD speech-start edge to the motion stack."""
+        if self._motion_stack is None:
+            return
+        self._motion_stack_call("enter_child_speech")
+
+    def on_speech_stopped(self) -> None:
+        """Forward the VAD speech-stop edge to the motion stack."""
+        if self._motion_stack is None:
+            return
+        self._motion_stack_call("exit_child_speech")
+
+    def additional_tool_specs(self) -> list:
+        """Tool specs the realtime handler should add to ``session.update``.
+
+        Empty when no motion stack is wired or when the gestures layer
+        is disabled.
+        """
+        if self._motion_stack is None:
+            return []
+        try:
+            return list(self._motion_stack.additional_tool_specs())
+        except Exception as exc:
+            self._log.warning(
+                "[kids_teacher_robot_bridge] additional_tool_specs raised: %s",
+                exc,
+            )
+            return []
+
+    def additional_instructions(self) -> str:
+        """Optional system-prompt extension. Empty when motion stack is absent."""
+        if self._motion_stack is None:
+            return ""
+        try:
+            return self._motion_stack.gesture_vocabulary_prompt_block()
+        except Exception as exc:
+            self._log.warning(
+                "[kids_teacher_robot_bridge] gesture_vocabulary_prompt_block raised: %s",
+                exc,
+            )
+            return ""
 
     # ------------------------------------------------------------------
     # Internals
@@ -356,6 +474,28 @@ class KidsTeacherRobotHooks:
         except Exception as exc:
             self._log.warning(
                 "[kids_teacher_robot_bridge] %s() raised: %s", method_name, exc
+            )
+
+    def _motion_stack_call(self, method_name: str) -> None:
+        """Invoke a motion-stack method, swallowing any exception.
+
+        The stack methods are pure local state mutations (compose state,
+        set gain, flush queue) — but if anything raises we'd rather lose
+        the gesture cue than crash the bridge thread.
+        """
+        stack = self._motion_stack
+        if stack is None:
+            return
+        method = getattr(stack, method_name, None)
+        if method is None:
+            return
+        try:
+            method()
+        except Exception as exc:
+            self._log.warning(
+                "[kids_teacher_robot_bridge] motion_stack.%s raised: %s",
+                method_name,
+                exc,
             )
 
 

--- a/src/kids_teacher_types.py
+++ b/src/kids_teacher_types.py
@@ -190,3 +190,22 @@ class KidsTeacherRuntimeHooks(Protocol):
         event: KidsTranscriptEvent,
         audio: Optional[bytes] = None,
     ) -> None: ...
+
+    # Optional: handle a function tool call from the realtime model. Hooks
+    # that don't expose tools can omit this method — the handler probes
+    # via ``getattr`` and skips dispatch when absent. The hook is expected
+    # to return a string (typically JSON) the handler will ship back as
+    # the function output, or ``None`` to skip the ack entirely.
+    def handle_tool_call(  # pragma: no cover - protocol-only signature
+        self,
+        call_id: str,
+        name: str,
+        arguments: str,
+    ) -> Optional[str]: ...
+
+    # Optional: VAD edge notifications. The motion-director uses these to
+    # switch the face-tracking gain state and flush in-flight gestures.
+    # Hooks that don't care can omit either method.
+    def on_speech_started(self) -> None: ...  # pragma: no cover - protocol-only
+
+    def on_speech_stopped(self) -> None: ...  # pragma: no cover - protocol-only

--- a/src/motion/__init__.py
+++ b/src/motion/__init__.py
@@ -1,0 +1,26 @@
+"""Motion director — three-layer additive motion stack for kids-teacher mode.
+
+See ``tasks/plan-motion-director.md`` for the design. The package is split:
+
+* :mod:`motion.types` — shared :class:`PoseOffset` value type.
+* :mod:`motion.library` — named choreography clips (L2 vocabulary).
+* :mod:`motion.composer` — the per-tick layer mixer that hands a final
+  pose to a sink (the sink is the bridge's adapter to ``RobotController``).
+
+L1/L2/L3 sources (audio wobbler, LLM-gesture scheduler, face-offset mixer)
+plug into the composer via ``set_wobble_source`` / ``play_clip`` /
+``set_face_offset_source``. None of those modules import each other; they
+only meet inside the composer.
+"""
+
+from motion.composer import MovementComposer
+from motion.library import Clip, ChoreographyLibrary, default_library
+from motion.types import PoseOffset
+
+__all__ = [
+    "Clip",
+    "ChoreographyLibrary",
+    "MovementComposer",
+    "PoseOffset",
+    "default_library",
+]

--- a/src/motion/composer.py
+++ b/src/motion/composer.py
@@ -1,0 +1,268 @@
+"""60 Hz-class additive layer composer for the motion director.
+
+Per ``tasks/plan-motion-director.md`` §4 the composer mixes:
+
+    pose = state pose (idle/listen/speak)
+         + primary clip (L2, sparse)
+         + L1 audio wobble (optional)
+         + L3 face offset (optional)
+
+The result is clipped against a safety cap and handed to a sink callable.
+The sink owns the SDK conversion (``create_head_pose`` etc.) so this module
+stays free of any robot SDK import.
+
+Threading model
+---------------
+The composer runs a single daemon thread that calls :meth:`tick` at
+``tick_hz``. All public methods are safe to call from any thread; mutating
+state takes a short lock. :meth:`tick` also runs under the lock so a
+mid-tick ``play_clip`` can't tear the active clip mid-evaluation.
+
+For tests, drive the composer manually via :meth:`tick_at` or
+:meth:`compose_pose` and skip :meth:`start` / :meth:`stop`.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from typing import Callable, Dict, Optional
+
+from motion.library import Clip
+from motion.types import NEUTRAL, PoseOffset
+
+logger = logging.getLogger(__name__)
+
+PoseSink = Callable[[PoseOffset, float], None]
+PoseSource = Callable[[], PoseOffset]
+
+
+_DEG = math.pi / 180.0
+
+
+# State -> pose mapping. ``idle`` is neutral so the wobble / face layers
+# define the only motion at rest; ``listen`` reproduces the existing
+# RobotController.listen() pose; ``speak`` is neutral because L1 wobble
+# drives the head-bob equivalent.
+DEFAULT_STATE_POSES: Dict[str, PoseOffset] = {
+    "idle": NEUTRAL,
+    "listen": PoseOffset(head_roll=15.0 * _DEG),
+    "speak": NEUTRAL,
+}
+
+
+# Final output safety caps. Generous enough to accommodate the listen-state
+# 15° roll plus a clip envelope; tight enough that a runaway source can't
+# whip the head. Tune in Phase 1+ once we have hardware in the loop.
+DEFAULT_SAFETY_CAPS = PoseOffset(
+    head_pitch=25.0 * _DEG,
+    head_yaw=25.0 * _DEG,
+    head_roll=25.0 * _DEG,
+    head_x=0.020,  # 20 mm
+    head_y=0.020,
+    head_z=0.020,
+    antenna_left=70.0 * _DEG,
+    antenna_right=70.0 * _DEG,
+)
+
+
+class MovementComposer:
+    """Per-tick layer mixer feeding a single pose sink.
+
+    See module docstring for the composition rule. The composer is created
+    in a stopped state with no active clip and no L1/L3 sources; the bridge
+    wires sources in as each layer comes online.
+    """
+
+    def __init__(
+        self,
+        *,
+        pose_sink: PoseSink,
+        tick_hz: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+        state_poses: Optional[Dict[str, PoseOffset]] = None,
+        safety_caps: PoseOffset = DEFAULT_SAFETY_CAPS,
+        logger_override: Optional[logging.Logger] = None,
+    ) -> None:
+        if tick_hz <= 0.0:
+            raise ValueError(f"tick_hz must be positive, got {tick_hz!r}")
+        self._sink = pose_sink
+        self._tick_hz = float(tick_hz)
+        self._tick_period = 1.0 / self._tick_hz
+        self._clock = clock
+        self._state_poses = dict(state_poses) if state_poses else dict(DEFAULT_STATE_POSES)
+        self._caps = safety_caps
+        self._log = logger_override or logger
+
+        self._lock = threading.Lock()
+        self._state: str = "idle"
+        self._active_clip: Optional[Clip] = None
+        self._clip_started_at: Optional[float] = None
+        self._wobble_source: Optional[PoseSource] = None
+        self._face_offset_source: Optional[PoseSource] = None
+
+        self._stop_flag = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # ------------------------------------------------------------------
+    # Configuration (thread-safe)
+    # ------------------------------------------------------------------
+
+    def set_state(self, state: str) -> None:
+        """Switch the base state pose. Unknown states fall back to ``idle``."""
+        with self._lock:
+            if state not in self._state_poses:
+                self._log.warning(
+                    "[motion.composer] unknown state %r; falling back to idle", state
+                )
+                self._state = "idle"
+            else:
+                self._state = state
+
+    def play_clip(self, clip: Clip) -> None:
+        """Start a clip on the L2 lane. Replaces any in-flight clip."""
+        with self._lock:
+            self._active_clip = clip
+            self._clip_started_at = self._clock()
+
+    def cancel_clip(self) -> None:
+        """Drop the active L2 clip. The L1/L3 layers continue."""
+        with self._lock:
+            self._active_clip = None
+            self._clip_started_at = None
+
+    def set_wobble_source(self, source: Optional[PoseSource]) -> None:
+        with self._lock:
+            self._wobble_source = source
+
+    def set_face_offset_source(self, source: Optional[PoseSource]) -> None:
+        with self._lock:
+            self._face_offset_source = source
+
+    # ------------------------------------------------------------------
+    # Tick / compose
+    # ------------------------------------------------------------------
+
+    def compose_pose(self, now: Optional[float] = None) -> PoseOffset:
+        """Return the composed pose for ``now`` without invoking the sink.
+
+        Pure with respect to the composer's current configuration — used by
+        tests to assert layer math directly.
+        """
+        if now is None:
+            now = self._clock()
+        with self._lock:
+            base = self._state_poses.get(self._state, NEUTRAL)
+            clip_offset = self._eval_clip_locked(now)
+            wobble = _safe_call(self._wobble_source, self._log, "wobble_source")
+            face = _safe_call(self._face_offset_source, self._log, "face_offset_source")
+        return (base + clip_offset + wobble + face).clipped(self._caps)
+
+    def tick(self) -> PoseOffset:
+        """Compose the current pose and hand it to the sink.
+
+        Returns the composed offset for caller introspection / telemetry.
+        """
+        now = self._clock()
+        offset = self.compose_pose(now)
+        try:
+            self._sink(offset, self._tick_period)
+        except Exception as exc:
+            self._log.warning("[motion.composer] pose_sink raised: %s", exc)
+        return offset
+
+    def tick_at(self, now: float) -> PoseOffset:
+        """Test helper: tick using an explicit clock value."""
+        offset = self.compose_pose(now)
+        try:
+            self._sink(offset, self._tick_period)
+        except Exception as exc:
+            self._log.warning("[motion.composer] pose_sink raised: %s", exc)
+        return offset
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn the daemon ticking thread. Idempotent."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_flag.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="motion-composer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 1.0) -> None:
+        """Signal the loop to exit and wait briefly. Idempotent."""
+        self._stop_flag.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                self._log.warning(
+                    "[motion.composer] composer thread did not exit in %.1fs",
+                    timeout,
+                )
+        self._thread = None
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        next_tick = self._clock()
+        while not self._stop_flag.is_set():
+            self.tick()
+            next_tick += self._tick_period
+            sleep_for = next_tick - self._clock()
+            if sleep_for > 0:
+                # Wait on the stop flag so shutdown doesn't have to ride out
+                # a full tick period.
+                self._stop_flag.wait(timeout=sleep_for)
+            else:
+                # We fell behind — rebase so we don't burn CPU catching up.
+                next_tick = self._clock()
+
+    def _eval_clip_locked(self, now: float) -> PoseOffset:
+        clip = self._active_clip
+        started_at = self._clip_started_at
+        if clip is None or started_at is None:
+            return NEUTRAL
+        elapsed = now - started_at
+        if elapsed < 0.0 or elapsed >= clip.duration:
+            self._active_clip = None
+            self._clip_started_at = None
+            return NEUTRAL
+        try:
+            return clip.pose_at(elapsed)
+        except Exception as exc:
+            self._log.warning(
+                "[motion.composer] clip %r pose_at(%.3f) raised: %s — dropping",
+                clip.name,
+                elapsed,
+                exc,
+            )
+            self._active_clip = None
+            self._clip_started_at = None
+            return NEUTRAL
+
+
+def _safe_call(
+    source: Optional[PoseSource], log: logging.Logger, label: str
+) -> PoseOffset:
+    if source is None:
+        return NEUTRAL
+    try:
+        offset = source()
+    except Exception as exc:
+        log.debug("[motion.composer] %s raised: %s", label, exc)
+        return NEUTRAL
+    if offset is None:
+        return NEUTRAL
+    return offset

--- a/src/motion/face_offset.py
+++ b/src/motion/face_offset.py
@@ -1,0 +1,248 @@
+"""L3 face-tracking offset mixer.
+
+Subscribes to :class:`face_tracker.FaceTracker` and turns its 3 Hz
+``(pan, tilt) ∈ [-1, 1]²`` publishes into smooth additive head offsets the
+composer can blend on top of the state pose. Per
+``tasks/plan-motion-director.md`` §6.3:
+
+* 3 Hz publish → ~60 Hz consume → ease toward target rather than snap.
+* Hard caps: ±20° pan, ±15° tilt, ~60°/s angular velocity.
+* Three gain states tied to VAD / playback edges:
+
+  ============  ======  ===========
+  state          gain   target source
+  ============  ======  ===========
+  idle           0.7    latest tracker publish (or last good if None)
+  child_speak    1.0    latest tracker publish (or last good if None)
+  robot_speak    0.4    held — do **not** re-pick mid-utterance
+  ============  ======  ===========
+
+* When the tracker publishes ``None`` (no subject), the mixer eases the
+  offset back to zero over ``no_target_release_s``. Hardware shutdown
+  surfaces as the same path because :meth:`FaceTracker.run` publishes
+  ``None`` on stop.
+
+The mixer never imports the FaceTracker class — :meth:`attach` accepts
+anything with a Pollen-shaped ``subscribe(callback) -> unsubscribe`` API.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from typing import Any, Callable, Optional, Tuple
+
+from motion.types import NEUTRAL, PoseOffset
+
+logger = logging.getLogger(__name__)
+
+
+_DEG = math.pi / 180.0
+
+
+# Hard caps from plan §6.3.
+MAX_PAN_RAD = 20.0 * _DEG
+MAX_TILT_RAD = 15.0 * _DEG
+MAX_ANGULAR_VELOCITY_RAD_S = 60.0 * _DEG
+
+# Default gain table.
+DEFAULT_GAINS = {
+    "idle": 0.7,
+    "child_speaking": 1.0,
+    "robot_speaking": 0.4,
+}
+
+# How long to ease the offset back to neutral after the tracker publishes
+# ``None`` (no subject). Matches the plan's "ease back to zero" behavior on
+# tracker shutdown / lost subject.
+DEFAULT_NO_TARGET_RELEASE_S = 0.6
+
+# Mapping convention: pan > 0 is right-of-center → head_yaw > 0 (head turns
+# right). tilt > 0 is below-center → head_pitch > 0 (head looks down).
+
+
+GazeTarget = Optional[Tuple[float, float]]
+_Subscribe = Callable[[Callable[[GazeTarget], None]], Callable[[], None]]
+
+
+class FaceOffsetMixer:
+    """Composer-facing additive offset source backed by the FaceTracker."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        gains: Optional[dict] = None,
+        max_pan_rad: float = MAX_PAN_RAD,
+        max_tilt_rad: float = MAX_TILT_RAD,
+        max_angular_velocity_rad_s: float = MAX_ANGULAR_VELOCITY_RAD_S,
+        no_target_release_s: float = DEFAULT_NO_TARGET_RELEASE_S,
+        logger_override: Optional[logging.Logger] = None,
+    ) -> None:
+        self._clock = clock
+        self._gains = dict(gains) if gains else dict(DEFAULT_GAINS)
+        self._max_pan = max_pan_rad
+        self._max_tilt = max_tilt_rad
+        self._max_velocity = max_angular_velocity_rad_s
+        self._no_target_release_s = no_target_release_s
+        self._log = logger_override or logger
+
+        self._lock = threading.Lock()
+        self._gain_state: str = "idle"
+        # Latest target from the tracker. ``None`` means "no subject right
+        # now"; we blend toward zero in that case.
+        self._tracker_target: GazeTarget = None
+        self._tracker_target_at: Optional[float] = None
+        # Cached last good target — used during robot_speaking to lock onto
+        # whoever we were looking at when the assistant started talking.
+        self._held_target: GazeTarget = None
+        # Current displayed offset (post-smoothing). Drives the velocity
+        # cap and is what the composer reads each tick.
+        self._displayed_offset: PoseOffset = NEUTRAL
+        self._displayed_at: Optional[float] = None
+
+        self._unsubscribe: Optional[Callable[[], None]] = None
+
+    # ------------------------------------------------------------------
+    # Tracker integration
+    # ------------------------------------------------------------------
+
+    def attach(self, tracker: Any) -> None:
+        """Subscribe to ``tracker.subscribe(...)``. Idempotent.
+
+        Caller is responsible for the tracker's own lifecycle (start/stop).
+        """
+        if self._unsubscribe is not None:
+            return
+        try:
+            self._unsubscribe = tracker.subscribe(self._on_target)
+        except AttributeError as exc:
+            raise TypeError(
+                "FaceOffsetMixer.attach: tracker has no subscribe(callback) API"
+            ) from exc
+
+    def detach(self) -> None:
+        """Unsubscribe from the tracker. Idempotent."""
+        unsub = self._unsubscribe
+        self._unsubscribe = None
+        if unsub is None:
+            return
+        try:
+            unsub()
+        except Exception as exc:
+            self._log.debug("[motion.face_offset] unsubscribe raised: %s", exc)
+
+    def _on_target(self, target: GazeTarget) -> None:
+        """Subscriber callback — runs from the FaceTracker's loop."""
+        now = self._clock()
+        with self._lock:
+            self._tracker_target = target
+            self._tracker_target_at = now
+            if target is not None:
+                # Update the held-target snapshot so a transition into
+                # robot_speaking locks onto the freshest known subject.
+                self._held_target = target
+
+    # ------------------------------------------------------------------
+    # Gain state
+    # ------------------------------------------------------------------
+
+    def set_gain_state(self, state: str) -> None:
+        """Switch gain. Snapshots the held target on robot_speaking entry."""
+        with self._lock:
+            if state not in self._gains:
+                self._log.warning(
+                    "[motion.face_offset] unknown gain state %r; ignoring",
+                    state,
+                )
+                return
+            if state == "robot_speaking" and self._tracker_target is not None:
+                # Lock onto the freshest known target so a stale held value
+                # doesn't make us look at the wrong place.
+                self._held_target = self._tracker_target
+            self._gain_state = state
+
+    @property
+    def gain_state(self) -> str:
+        return self._gain_state
+
+    # ------------------------------------------------------------------
+    # Composer-facing source
+    # ------------------------------------------------------------------
+
+    def current_offset(self) -> PoseOffset:
+        """Return the current additive head offset.
+
+        Smooths from the previously-displayed offset toward the target at
+        ``max_angular_velocity_rad_s``. Composer queries this on every tick.
+        """
+        now = self._clock()
+        with self._lock:
+            target_offset = self._target_offset_locked(now)
+            displayed = self._slew_locked(target_offset, now)
+            self._displayed_offset = displayed
+            self._displayed_at = now
+            return displayed
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _target_offset_locked(self, now: float) -> PoseOffset:
+        gain = self._gains.get(self._gain_state, 0.0)
+
+        # Robot-speaking mode locks onto the snapshot taken when we entered
+        # this state. We do NOT honor "tracker publishes None" here —
+        # holding still is the desired behavior during a robot utterance.
+        if self._gain_state == "robot_speaking":
+            target = self._held_target
+        else:
+            target = self._tracker_target
+            # No subject right now: ease toward zero. We let the slew limiter
+            # do that for us by returning NEUTRAL as the target. After
+            # ``no_target_release_s`` we're effectively at zero anyway.
+            if target is None:
+                _ = self._no_target_release_s  # documented; slew handles it
+                return NEUTRAL
+
+        if target is None:
+            return NEUTRAL
+
+        pan, tilt = target
+        head_yaw = _clamp(pan * self._max_pan, self._max_pan) * gain
+        head_pitch = _clamp(tilt * self._max_tilt, self._max_tilt) * gain
+        return PoseOffset(head_yaw=head_yaw, head_pitch=head_pitch)
+
+    def _slew_locked(self, target: PoseOffset, now: float) -> PoseOffset:
+        """Move the displayed offset toward ``target`` under the velocity cap."""
+        last_at = self._displayed_at
+        if last_at is None:
+            # First tick — snap so we start tracking immediately.
+            return target
+        dt = max(now - last_at, 0.0)
+        if dt <= 0.0:
+            return self._displayed_offset
+        max_step = self._max_velocity * dt
+        return PoseOffset(
+            head_yaw=_step_toward(self._displayed_offset.head_yaw, target.head_yaw, max_step),
+            head_pitch=_step_toward(
+                self._displayed_offset.head_pitch, target.head_pitch, max_step
+            ),
+        )
+
+
+def _clamp(value: float, cap: float) -> float:
+    if value > cap:
+        return cap
+    if value < -cap:
+        return -cap
+    return value
+
+
+def _step_toward(current: float, target: float, max_step: float) -> float:
+    delta = target - current
+    if abs(delta) <= max_step:
+        return target
+    return current + math.copysign(max_step, delta)

--- a/src/motion/library.py
+++ b/src/motion/library.py
@@ -1,0 +1,253 @@
+"""Named choreography clips — the L2 gesture vocabulary.
+
+Each clip is a function-of-time returning an additive :class:`PoseOffset`.
+The composer evaluates the active clip at every tick and blends the result
+on top of the state pose, the L1 wobble, and the L3 face offset.
+
+Clips are intentionally analytical (sinusoids, ramps): no keyframe-asset
+loader, no HuggingFace pull, no extra deps. V1 ships ~8 clips covering
+affect, celebration, system. Pedagogical clips (`count_bob`, `mimicry`,
+`point_with_gaze`) are Phase 4 per ``tasks/plan-motion-director.md``.
+
+Lane semantics — used by the scheduler for priority + debounce:
+
+* ``safety``      — emergency stop / clamp.
+* ``system``      — composer-driven (cancel / reset).
+* ``celebration`` — long-form rewards (mini_dance, victory).
+* ``affect``      — short emotional reactions (nod, tilt, pop, droop).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List
+
+from motion.types import NEUTRAL, PoseOffset
+
+PoseAt = Callable[[float], PoseOffset]
+
+
+@dataclass(frozen=True)
+class Clip:
+    """A named pose trajectory.
+
+    ``pose_at(t)`` is queried with ``t`` in the half-open interval
+    ``[0, duration)``. Outside that range the composer treats the clip as
+    finished and stops querying it.
+    """
+
+    name: str
+    duration: float
+    lane: str
+    pose_at: PoseAt
+
+
+class ChoreographyLibrary:
+    """Registry of named clips.
+
+    Looking up an unknown name returns ``None`` — the scheduler logs and
+    drops the gesture rather than executing surprise motion.
+    """
+
+    def __init__(self, clips: Iterable[Clip] = ()) -> None:
+        self._clips: Dict[str, Clip] = {}
+        for clip in clips:
+            self.register(clip)
+
+    def register(self, clip: Clip) -> None:
+        if clip.name in self._clips:
+            raise ValueError(f"clip {clip.name!r} already registered")
+        self._clips[clip.name] = clip
+
+    def get(self, name: str) -> Clip | None:
+        return self._clips.get(name)
+
+    def names(self) -> List[str]:
+        return sorted(self._clips)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._clips
+
+
+# ---------------------------------------------------------------------------
+# V1 clips
+# ---------------------------------------------------------------------------
+
+_DEG = math.pi / 180.0
+
+
+def _ease_in_out(u: float) -> float:
+    """Smoothstep on ``u`` clamped to ``[0, 1]`` — used for ramp envelopes."""
+    if u <= 0.0:
+        return 0.0
+    if u >= 1.0:
+        return 1.0
+    return u * u * (3.0 - 2.0 * u)
+
+
+def _envelope(t: float, duration: float, ramp: float) -> float:
+    """Trapezoid envelope: ramp up over ``ramp``, hold, ramp down over ``ramp``."""
+    if duration <= 0.0:
+        return 0.0
+    if t <= 0.0 or t >= duration:
+        return 0.0
+    fall_start = duration - ramp
+    if t < ramp:
+        return _ease_in_out(t / ramp)
+    if t > fall_start:
+        return _ease_in_out((duration - t) / ramp)
+    return 1.0
+
+
+def _nod_encourage(duration: float = 1.6) -> PoseAt:
+    amp = 8.0 * _DEG
+    cycles = 2
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.2)
+        phase = 2.0 * math.pi * cycles * (t / duration)
+        return PoseOffset(head_pitch=-amp * env * math.sin(phase))
+
+    return _at
+
+
+def _head_tilt_curious(duration: float = 2.0) -> PoseAt:
+    target_roll = 15.0 * _DEG
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.4)
+        return PoseOffset(head_roll=target_roll * env)
+
+    return _at
+
+
+def _mini_dance_excited(duration: float = 2.0) -> PoseAt:
+    bounce_amp_m = 0.012  # 12 mm head z bounce
+    antenna_amp = 25.0 * _DEG
+    bounce_cycles = 4
+    antenna_cycles = 6
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.25)
+        bounce_phase = 2.0 * math.pi * bounce_cycles * (t / duration)
+        antenna_phase = 2.0 * math.pi * antenna_cycles * (t / duration)
+        bounce = bounce_amp_m * env * abs(math.sin(bounce_phase))
+        wiggle = antenna_amp * env * math.sin(antenna_phase)
+        return PoseOffset(
+            head_z=bounce,
+            antenna_left=wiggle,
+            antenna_right=-wiggle,
+        )
+
+    return _at
+
+
+def _victory_wiggle(duration: float = 2.5) -> PoseAt:
+    nod_amp = 10.0 * _DEG
+    antenna_amp = 35.0 * _DEG
+    nod_cycles = 3
+    antenna_cycles = 8
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.3)
+        nod_phase = 2.0 * math.pi * nod_cycles * (t / duration)
+        antenna_phase = 2.0 * math.pi * antenna_cycles * (t / duration)
+        return PoseOffset(
+            head_pitch=-nod_amp * env * math.sin(nod_phase),
+            antenna_left=antenna_amp * env * math.sin(antenna_phase),
+            antenna_right=-antenna_amp * env * math.sin(antenna_phase),
+        )
+
+    return _at
+
+
+def _surprise_pop(duration: float = 0.8) -> PoseAt:
+    pitch_amp = 12.0 * _DEG  # head tips back
+    antenna_amp = 30.0 * _DEG
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        u = t / duration
+        # Asymmetric: snap up in first 25%, ease back over the rest.
+        if u < 0.25:
+            env = _ease_in_out(u / 0.25)
+        else:
+            env = _ease_in_out((1.0 - u) / 0.75)
+        return PoseOffset(
+            head_pitch=pitch_amp * env,
+            antenna_left=antenna_amp * env,
+            antenna_right=antenna_amp * env,
+        )
+
+    return _at
+
+
+def _sad_droop(duration: float = 1.5) -> PoseAt:
+    pitch_amp = 10.0 * _DEG  # head down
+    antenna_amp = -25.0 * _DEG  # antennas drop
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.4)
+        return PoseOffset(
+            head_pitch=-pitch_amp * env,
+            antenna_left=antenna_amp * env,
+            antenna_right=antenna_amp * env,
+        )
+
+    return _at
+
+
+def _thinking_up(duration: float = 2.0) -> PoseAt:
+    pitch_amp = 8.0 * _DEG  # gaze up
+    roll_amp = 5.0 * _DEG  # slight tilt
+
+    def _at(t: float) -> PoseOffset:
+        if t < 0.0 or t >= duration:
+            return NEUTRAL
+        env = _envelope(t, duration, ramp=0.4)
+        return PoseOffset(
+            head_pitch=pitch_amp * env,
+            head_roll=roll_amp * env,
+        )
+
+    return _at
+
+
+def _cancel(duration: float = 0.4) -> PoseAt:
+    """No-op clip used by the scheduler to occupy the L2 lane while the
+    composer eases the primary offset back toward neutral. Always returns
+    :data:`NEUTRAL` — the easing happens in the composer, not the clip.
+    """
+
+    def _at(t: float) -> PoseOffset:  # noqa: ARG001
+        return NEUTRAL
+
+    return _at
+
+
+def default_library() -> ChoreographyLibrary:
+    """Build the V1 vocabulary. Order is alphabetical for stability."""
+    return ChoreographyLibrary(
+        [
+            Clip("cancel", 0.4, "system", _cancel(0.4)),
+            Clip("head_tilt_curious", 2.0, "affect", _head_tilt_curious(2.0)),
+            Clip("mini_dance_excited", 2.0, "celebration", _mini_dance_excited(2.0)),
+            Clip("nod_encourage", 1.6, "affect", _nod_encourage(1.6)),
+            Clip("sad_droop", 1.5, "affect", _sad_droop(1.5)),
+            Clip("surprise_pop", 0.8, "affect", _surprise_pop(0.8)),
+            Clip("thinking_up", 2.0, "affect", _thinking_up(2.0)),
+            Clip("victory_wiggle", 2.5, "celebration", _victory_wiggle(2.5)),
+        ]
+    )

--- a/src/motion/scheduler.py
+++ b/src/motion/scheduler.py
@@ -1,0 +1,217 @@
+"""L2 gesture scheduler — priority, debounce, rate cap, barge-in.
+
+Sits between the LLM (or any other gesture source) and the
+:class:`MovementComposer`. Enforces the rules from
+``tasks/plan-motion-director.md`` §7:
+
+* **Priority lanes** — ``safety`` > ``system`` > ``celebration`` > ``affect``
+  > ``idle_filler``. Higher-lane requests pre-empt lower-lane in-flight
+  clips; equal-or-lower-lane requests drop while a clip is playing.
+* **Debounce** — the same gesture can't repeat within
+  :data:`DEFAULT_PER_NAME_COOLDOWN_S`.
+* **Rate cap** — L2 fires at most once per
+  :data:`DEFAULT_GLOBAL_COOLDOWN_S`.
+* **Barge-in** — :meth:`flush` cancels the in-flight clip without
+  trampling debounce timers.
+
+Every decision is reported through an optional callback so the bridge can
+log it to ``kids_review_store`` or wherever telemetry lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+from motion.composer import MovementComposer
+from motion.library import ChoreographyLibrary, Clip
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_PER_NAME_COOLDOWN_S = 8.0
+DEFAULT_GLOBAL_COOLDOWN_S = 4.0
+
+
+# Higher number = higher priority. The "celebration" lane preempts "affect"
+# (matching plan §7: "Long clips (`dance`) get their own lane and pre-empt
+# shorter affect clips.").
+LANE_PRIORITY: Dict[str, int] = {
+    "safety": 5,
+    "system": 4,
+    "celebration": 3,
+    "affect": 2,
+    "idle_filler": 1,
+}
+
+
+@dataclass(frozen=True)
+class GestureDecision:
+    """Outcome of a single :meth:`GestureScheduler.request` call.
+
+    ``accepted`` is ``True`` when the clip was started (possibly preempting
+    a lower-lane clip). When ``False``, ``reason`` names the rule that
+    dropped it: ``unknown_gesture``, ``per_name_cooldown``,
+    ``global_cooldown``, or ``lower_priority``.
+    """
+
+    name: str
+    accepted: bool
+    reason: Optional[str]
+    lane: Optional[str]
+
+
+DecisionLogger = Callable[[GestureDecision], None]
+
+
+class GestureScheduler:
+    """Priority + cooldown gate in front of :class:`MovementComposer`."""
+
+    def __init__(
+        self,
+        *,
+        composer: MovementComposer,
+        library: ChoreographyLibrary,
+        clock: Callable[[], float] = time.monotonic,
+        per_name_cooldown_s: float = DEFAULT_PER_NAME_COOLDOWN_S,
+        global_cooldown_s: float = DEFAULT_GLOBAL_COOLDOWN_S,
+        decision_logger: Optional[DecisionLogger] = None,
+        logger_override: Optional[logging.Logger] = None,
+    ) -> None:
+        self._composer = composer
+        self._library = library
+        self._clock = clock
+        self._per_name_cooldown_s = per_name_cooldown_s
+        self._global_cooldown_s = global_cooldown_s
+        self._decision_logger = decision_logger
+        self._log = logger_override or logger
+
+        self._lock = threading.Lock()
+        self._last_fire_at: Dict[str, float] = {}
+        self._global_last_fire_at: Optional[float] = None
+        self._active_clip: Optional[Clip] = None
+        self._active_started_at: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    # Public entry
+    # ------------------------------------------------------------------
+
+    def request(self, name: str) -> GestureDecision:
+        """Try to play the named gesture. Returns the decision + reason."""
+        clip = self._library.get(name)
+        if clip is None:
+            decision = GestureDecision(
+                name=name, accepted=False, reason="unknown_gesture", lane=None
+            )
+            self._emit(decision)
+            return decision
+
+        now = self._clock()
+        with self._lock:
+            decision = self._evaluate_locked(clip, now)
+            if decision.accepted:
+                self._active_clip = clip
+                self._active_started_at = now
+                self._last_fire_at[name] = now
+                self._global_last_fire_at = now
+
+        if decision.accepted:
+            # Composer call goes outside the scheduler lock — it takes its
+            # own lock and we don't want to block other request() callers.
+            self._composer.play_clip(clip)
+        self._emit(decision)
+        return decision
+
+    def flush(self) -> None:
+        """Cancel the active clip without resetting cooldown timers.
+
+        Called on barge-in (child speaks while a gesture is mid-flight)
+        per plan §7 rule 4. Debounce + rate-cap state is preserved so the
+        scheduler doesn't immediately re-fire a duplicate gesture.
+        """
+        with self._lock:
+            self._active_clip = None
+            self._active_started_at = None
+        self._composer.cancel_clip()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _evaluate_locked(self, clip: Clip, now: float) -> GestureDecision:
+        # Per-name cooldown — same gesture can't repeat within window.
+        last_for_name = self._last_fire_at.get(clip.name)
+        if (
+            last_for_name is not None
+            and (now - last_for_name) < self._per_name_cooldown_s
+        ):
+            return GestureDecision(
+                name=clip.name,
+                accepted=False,
+                reason="per_name_cooldown",
+                lane=clip.lane,
+            )
+
+        # Global rate cap — at most one L2 fire per window. System-lane
+        # gestures (e.g. ``cancel``) bypass the rate cap so the scheduler
+        # can always force a stop without waiting out the cooldown.
+        is_system_or_safety = LANE_PRIORITY.get(clip.lane, 0) >= LANE_PRIORITY["system"]
+        if (
+            not is_system_or_safety
+            and self._global_last_fire_at is not None
+            and (now - self._global_last_fire_at) < self._global_cooldown_s
+        ):
+            return GestureDecision(
+                name=clip.name,
+                accepted=False,
+                reason="global_cooldown",
+                lane=clip.lane,
+            )
+
+        # Lane priority — only preempt lower-lane in-flight clips.
+        if self._active_clip is not None and self._active_started_at is not None:
+            elapsed = now - self._active_started_at
+            still_playing = elapsed < self._active_clip.duration
+            if still_playing:
+                requested_priority = LANE_PRIORITY.get(clip.lane, 0)
+                active_priority = LANE_PRIORITY.get(self._active_clip.lane, 0)
+                if requested_priority <= active_priority:
+                    return GestureDecision(
+                        name=clip.name,
+                        accepted=False,
+                        reason="lower_priority",
+                        lane=clip.lane,
+                    )
+            else:
+                # Clip already ran out — clear stale state.
+                self._active_clip = None
+                self._active_started_at = None
+
+        return GestureDecision(
+            name=clip.name, accepted=True, reason=None, lane=clip.lane
+        )
+
+    def _emit(self, decision: GestureDecision) -> None:
+        if decision.accepted:
+            self._log.info(
+                "[motion.scheduler] play %r (lane=%s)",
+                decision.name,
+                decision.lane,
+            )
+        else:
+            self._log.debug(
+                "[motion.scheduler] drop %r (lane=%s reason=%s)",
+                decision.name,
+                decision.lane,
+                decision.reason,
+            )
+        cb = self._decision_logger
+        if cb is None:
+            return
+        try:
+            cb(decision)
+        except Exception as exc:
+            self._log.debug("[motion.scheduler] decision_logger raised: %s", exc)

--- a/src/motion/stack.py
+++ b/src/motion/stack.py
@@ -1,0 +1,276 @@
+"""Motion-director orchestration — bundles L1/L2/L3 + composer.
+
+The bridge owns one :class:`MotionStack`. The stack hides the wiring of:
+
+* :class:`AudioWobbler` (L1)        — fed assistant TTS chunks.
+* :class:`MovementComposer`         — 30 Hz layer mixer driving the SDK.
+* :class:`GestureScheduler`         — L2 gesture queue + priority gate.
+* :class:`GestureToolRouter`        — LLM tool surface for ``play_gesture``
+  and ``stop_motion``.
+* :class:`FaceOffsetMixer` (L3)     — subscribes to the existing
+  :class:`face_tracker.FaceTracker`.
+
+Each layer can be disabled at construction so the operator (or a kill-switch
+env var) can land an audit-only release. A ``MotionStack`` with no layers
+enabled still constructs a composer driving the legacy speak / listen /
+idle state pose; that's the minimum overlay needed to keep the bridge's
+new code path coherent without exposing aliveness yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, FrozenSet, Iterable, List, Optional
+
+from motion.composer import MovementComposer
+from motion.face_offset import FaceOffsetMixer
+from motion.library import ChoreographyLibrary, default_library
+from motion.scheduler import GestureScheduler
+from motion.tool_specs import (
+    GestureToolRouter,
+    ToolCallResult,
+    gesture_tool_specs,
+    gesture_vocabulary_prompt_block,
+)
+from motion.types import PoseOffset
+from motion.wobbler import AudioWobbler
+
+logger = logging.getLogger(__name__)
+
+
+# Layer names recognised by the stack. ``composer`` is implicit (always on).
+LAYER_WOBBLE = "wobble"
+LAYER_GESTURES = "gestures"
+LAYER_TRACKING = "tracking"
+ALL_LAYERS: FrozenSet[str] = frozenset({LAYER_WOBBLE, LAYER_GESTURES, LAYER_TRACKING})
+
+
+def parse_layers(spec: Optional[str]) -> FrozenSet[str]:
+    """Parse a ``KIDS_TEACHER_MOTION_LAYERS`` value into a layer set.
+
+    Recognised values:
+
+    * ``None`` / ``""`` / ``"full"`` → all layers
+    * ``"none"``                     → empty set
+    * comma-separated layer names   → matching subset (unknown names logged
+      and dropped)
+    """
+    if spec is None:
+        return ALL_LAYERS
+    raw = spec.strip().lower()
+    if not raw or raw == "full":
+        return ALL_LAYERS
+    if raw == "none":
+        return frozenset()
+    parts = {p.strip() for p in raw.split(",") if p.strip()}
+    layers = parts & ALL_LAYERS
+    unknown = parts - ALL_LAYERS
+    if unknown:
+        logger.warning(
+            "[motion.stack] ignoring unknown motion layers: %s", sorted(unknown)
+        )
+    return frozenset(layers)
+
+
+@dataclass(frozen=True)
+class MotionStackConfig:
+    layers: FrozenSet[str] = ALL_LAYERS
+    tick_hz: float = 30.0
+    audio_sample_rate: int = 24000
+
+
+class MotionStack:
+    """One orchestrator the bridge talks to instead of four separate objects.
+
+    Construction never starts the composer thread; call :meth:`start` after
+    wiring is complete. :meth:`stop` is idempotent.
+    """
+
+    def __init__(
+        self,
+        *,
+        robot_controller: Any,
+        config: MotionStackConfig = MotionStackConfig(),
+        library: Optional[ChoreographyLibrary] = None,
+        decision_logger=None,
+    ) -> None:
+        self._robot = robot_controller
+        self._config = config
+        self._library = library or default_library()
+
+        self._composer = MovementComposer(
+            pose_sink=self._pose_sink,
+            tick_hz=config.tick_hz,
+        )
+
+        self._wobbler: Optional[AudioWobbler] = None
+        if LAYER_WOBBLE in config.layers:
+            self._wobbler = AudioWobbler(sample_rate=config.audio_sample_rate)
+            self._composer.set_wobble_source(self._wobbler.current_offset)
+
+        self._scheduler: Optional[GestureScheduler] = None
+        self._tool_router: Optional[GestureToolRouter] = None
+        if LAYER_GESTURES in config.layers:
+            self._scheduler = GestureScheduler(
+                composer=self._composer,
+                library=self._library,
+                decision_logger=decision_logger,
+            )
+            self._tool_router = GestureToolRouter(scheduler=self._scheduler)
+
+        self._face_mixer: Optional[FaceOffsetMixer] = None
+        if LAYER_TRACKING in config.layers:
+            self._face_mixer = FaceOffsetMixer()
+            self._composer.set_face_offset_source(self._face_mixer.current_offset)
+
+        self._first_assistant_chunk_seen = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        self._composer.start()
+
+    def stop(self, timeout: float = 1.0) -> None:
+        self._composer.stop(timeout=timeout)
+        if self._face_mixer is not None:
+            self._face_mixer.detach()
+
+    # ------------------------------------------------------------------
+    # Bridge-facing event hooks
+    # ------------------------------------------------------------------
+
+    def feed_assistant_audio(self, chunk: bytes) -> None:
+        if self._wobbler is not None:
+            self._wobbler.feed(chunk)
+
+    def enter_assistant_speech(self) -> None:
+        """Called on the first audio chunk of an assistant turn."""
+        self._composer.set_state("speak")
+        if self._face_mixer is not None:
+            self._face_mixer.set_gain_state("robot_speaking")
+        self._first_assistant_chunk_seen = True
+
+    def exit_assistant_speech(self) -> None:
+        """Called when the turn ends or barge-in flushes playback."""
+        self._first_assistant_chunk_seen = False
+        if self._wobbler is not None:
+            self._wobbler.reset()
+        if self._scheduler is not None:
+            self._scheduler.flush()
+        self._composer.set_state("listen")
+        if self._face_mixer is not None:
+            self._face_mixer.set_gain_state("idle")
+
+    def enter_child_speech(self) -> None:
+        """Called on VAD ``speech_started``."""
+        if self._scheduler is not None:
+            self._scheduler.flush()
+        if self._wobbler is not None:
+            self._wobbler.reset()
+        self._composer.set_state("listen")
+        if self._face_mixer is not None:
+            self._face_mixer.set_gain_state("child_speaking")
+
+    def exit_child_speech(self) -> None:
+        """Called on VAD ``speech_stopped``.
+
+        Does not change the composer state — the assistant turn (or session
+        idle) decides what's next.
+        """
+        if self._face_mixer is not None and self._face_mixer.gain_state == "child_speaking":
+            self._face_mixer.set_gain_state("idle")
+
+    def set_idle(self) -> None:
+        """Called on session IDLE / ENDED status."""
+        self._composer.set_state("idle")
+        if self._face_mixer is not None:
+            self._face_mixer.set_gain_state("idle")
+
+    # ------------------------------------------------------------------
+    # Tool routing
+    # ------------------------------------------------------------------
+
+    def additional_tool_specs(self) -> List[dict]:
+        """Tool specs to inject into ``build_session_payload``.
+
+        Empty when the gestures layer is disabled.
+        """
+        if self._tool_router is None:
+            return []
+        return gesture_tool_specs(self._library)
+
+    def gesture_vocabulary_prompt_block(self) -> str:
+        """Prompt block describing the gesture vocabulary semantics.
+
+        Empty when the gestures layer is disabled — no point telling the
+        model about tools it can't call.
+        """
+        if self._tool_router is None:
+            return ""
+        return gesture_vocabulary_prompt_block()
+
+    def handle_tool_call(self, call_id: str, name: str, arguments: str) -> Optional[str]:
+        """Run a tool call and return a JSON ack string, or ``None``."""
+        del call_id  # opaque to the router; bridge owns the ack/no-ack policy
+        if self._tool_router is None:
+            return None
+        result = self._tool_router.dispatch(name, arguments)
+        return result.to_payload()
+
+    # ------------------------------------------------------------------
+    # L3 wiring
+    # ------------------------------------------------------------------
+
+    def attach_face_tracker(self, tracker: Any) -> None:
+        if self._face_mixer is None:
+            return
+        self._face_mixer.attach(tracker)
+
+    def detach_face_tracker(self) -> None:
+        if self._face_mixer is None:
+            return
+        self._face_mixer.detach()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _pose_sink(self, offset: PoseOffset, period: float) -> None:
+        apply = getattr(self._robot, "apply_pose", None)
+        if apply is None:
+            return
+        try:
+            apply(
+                head_pitch=offset.head_pitch,
+                head_yaw=offset.head_yaw,
+                head_roll=offset.head_roll,
+                head_x=offset.head_x,
+                head_y=offset.head_y,
+                head_z=offset.head_z,
+                antenna_left=offset.antenna_left,
+                antenna_right=offset.antenna_right,
+                duration=period,
+            )
+        except Exception as exc:
+            logger.debug("[motion.stack] apply_pose raised: %s", exc)
+
+
+# Convenience used by the CLI factory; importable for tests.
+def select_layers_from_iterable(layers: Iterable[str]) -> FrozenSet[str]:
+    return frozenset({l for l in layers if l in ALL_LAYERS})
+
+
+__all__ = [
+    "ALL_LAYERS",
+    "LAYER_GESTURES",
+    "LAYER_TRACKING",
+    "LAYER_WOBBLE",
+    "MotionStack",
+    "MotionStackConfig",
+    "ToolCallResult",
+    "parse_layers",
+    "select_layers_from_iterable",
+]

--- a/src/motion/tool_specs.py
+++ b/src/motion/tool_specs.py
@@ -1,0 +1,184 @@
+"""LLM tool specs + router for the L2 gesture vocabulary.
+
+Pollen's reference exposes ~7 motion tools to the Realtime model. We expose
+two for V1, both routed through :class:`GestureScheduler`:
+
+* ``play_gesture(name)`` — fire any clip from the choreography library.
+* ``stop_motion()``     — flush the scheduler (LLM-driven self-cancel).
+
+Why so few? Pollen's tool split (`dance` / `play_emotion` / `move_head`)
+exists because their HuggingFace clip libraries are split that way. Our
+clips are flat — one tool with an enum is enough. ``move_head`` belongs
+to the L3 face-tracking layer, not the L2 LLM tool surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, List, Mapping, Optional
+
+from motion.library import ChoreographyLibrary
+from motion.scheduler import GestureDecision, GestureScheduler
+
+logger = logging.getLogger(__name__)
+
+
+PLAY_GESTURE_TOOL_NAME = "play_gesture"
+STOP_MOTION_TOOL_NAME = "stop_motion"
+MOTION_TOOL_NAMES = (PLAY_GESTURE_TOOL_NAME, STOP_MOTION_TOOL_NAME)
+
+
+def gesture_tool_specs(library: ChoreographyLibrary) -> List[dict]:
+    """Build OpenAI Realtime ``function`` tool specs for the L2 vocabulary.
+
+    The ``play_gesture`` schema enumerates the clip names so the model can
+    only request gestures the library actually knows about — the scheduler
+    enforces this again at dispatch time, but pinning the enum at the API
+    boundary is cheap insurance.
+    """
+    return [
+        {
+            "type": "function",
+            "name": PLAY_GESTURE_TOOL_NAME,
+            "description": (
+                "Play a short expressive robot gesture (head + antenna motion) "
+                "to make the conversation feel alive. Pick a gesture that "
+                "matches the emotion you're conveying."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": library.names(),
+                        "description": "Name of the gesture clip to play.",
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "type": "function",
+            "name": STOP_MOTION_TOOL_NAME,
+            "description": (
+                "Stop any in-flight gesture immediately. Use when you've "
+                "changed your mind about expressing something."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+# A short paragraph the system prompt can include so the model knows what
+# each gesture *means*. Per plan §6.2 we describe semantics, not when-to-use.
+def gesture_vocabulary_prompt_block() -> str:
+    return (
+        "# Robot gestures\n"
+        "When you want to react physically to something, call play_gesture(name) "
+        "with one of these names:\n"
+        "- nod_encourage: gentle double nod for affirmation.\n"
+        "- head_tilt_curious: tilted head, like asking a question.\n"
+        "- mini_dance_excited: small celebration bounce for correct answers.\n"
+        "- victory_wiggle: bigger celebration for milestones.\n"
+        "- surprise_pop: quick head-up reaction to a surprise.\n"
+        "- sad_droop: head and antennas drop for sympathy.\n"
+        "- thinking_up: gaze upward while you think.\n"
+        "Call stop_motion() if you change your mind mid-gesture.\n"
+    )
+
+
+@dataclass(frozen=True)
+class ToolCallResult:
+    """Outcome of a single tool dispatch — what the bridge sends back."""
+
+    ok: bool
+    detail: str
+
+    def to_payload(self) -> str:
+        """JSON string suitable for the OpenAI ``function_call_output`` field."""
+        return json.dumps({"ok": self.ok, "detail": self.detail})
+
+
+class GestureToolRouter:
+    """Translate normalized ``tool.call`` events into scheduler actions.
+
+    Validates the tool name + arguments, calls into
+    :class:`GestureScheduler`, and returns a :class:`ToolCallResult` that
+    the caller can ship back to the LLM as a ``function_call_output``.
+
+    Unknown tool names and malformed argument payloads are reported as
+    ``ok=False`` with a short reason. The router never raises — bad
+    tool calls must not crash the realtime event loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        scheduler: GestureScheduler,
+        logger_override: Optional[logging.Logger] = None,
+    ) -> None:
+        self._scheduler = scheduler
+        self._log = logger_override or logger
+
+    @property
+    def tool_names(self) -> tuple[str, ...]:
+        return MOTION_TOOL_NAMES
+
+    def dispatch(self, name: str, arguments: Any) -> ToolCallResult:
+        if name == PLAY_GESTURE_TOOL_NAME:
+            return self._dispatch_play_gesture(arguments)
+        if name == STOP_MOTION_TOOL_NAME:
+            self._scheduler.flush()
+            return ToolCallResult(ok=True, detail="motion stopped")
+        self._log.info("[motion.tool_router] unknown tool %r", name)
+        return ToolCallResult(ok=False, detail=f"unknown tool: {name}")
+
+    def _dispatch_play_gesture(self, arguments: Any) -> ToolCallResult:
+        parsed = _coerce_arguments(arguments)
+        if parsed is None:
+            return ToolCallResult(ok=False, detail="invalid arguments JSON")
+        gesture_name = parsed.get("name")
+        if not isinstance(gesture_name, str) or not gesture_name:
+            return ToolCallResult(
+                ok=False, detail="play_gesture requires a non-empty 'name' string"
+            )
+        decision: GestureDecision = self._scheduler.request(gesture_name)
+        if decision.accepted:
+            return ToolCallResult(ok=True, detail=f"playing {decision.name}")
+        return ToolCallResult(
+            ok=False, detail=f"dropped: {decision.reason or 'unknown reason'}"
+        )
+
+
+def _coerce_arguments(arguments: Any) -> Optional[Mapping[str, Any]]:
+    """Tool-call arguments arrive either as a dict or a JSON string.
+
+    Returns ``None`` for anything that can't be coerced into a mapping
+    (which the caller surfaces as an error result).
+    """
+    if isinstance(arguments, Mapping):
+        return arguments
+    if isinstance(arguments, (bytes, bytearray)):
+        try:
+            arguments = arguments.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if isinstance(arguments, str):
+        if not arguments.strip():
+            return {}
+        try:
+            parsed = json.loads(arguments)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(parsed, Mapping):
+            return parsed
+        return None
+    return None

--- a/src/motion/types.py
+++ b/src/motion/types.py
@@ -1,0 +1,90 @@
+"""Shared value type for motion-director offsets.
+
+A :class:`PoseOffset` is an additive contribution to the robot's pose: head
+pitch/yaw/roll (radians), head x/y/z translation (metres), and per-antenna
+angles (radians). Layers (L1 wobble, L2 clip, L3 face offset) each produce
+a ``PoseOffset`` per tick; the composer sums them and clips the result
+against safety bounds before handing the final pose to the sink.
+
+All zero values are the neutral pose. Scalar-multiplication and addition are
+the only operations; they are all the composer needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class PoseOffset:
+    """Additive head + antenna offsets in SI units (radians, metres)."""
+
+    head_pitch: float = 0.0
+    head_yaw: float = 0.0
+    head_roll: float = 0.0
+    head_x: float = 0.0
+    head_y: float = 0.0
+    head_z: float = 0.0
+    antenna_left: float = 0.0
+    antenna_right: float = 0.0
+
+    def __add__(self, other: "PoseOffset") -> "PoseOffset":
+        if not isinstance(other, PoseOffset):
+            return NotImplemented
+        return PoseOffset(
+            head_pitch=self.head_pitch + other.head_pitch,
+            head_yaw=self.head_yaw + other.head_yaw,
+            head_roll=self.head_roll + other.head_roll,
+            head_x=self.head_x + other.head_x,
+            head_y=self.head_y + other.head_y,
+            head_z=self.head_z + other.head_z,
+            antenna_left=self.antenna_left + other.antenna_left,
+            antenna_right=self.antenna_right + other.antenna_right,
+        )
+
+    def scaled(self, gain: float) -> "PoseOffset":
+        return PoseOffset(
+            head_pitch=self.head_pitch * gain,
+            head_yaw=self.head_yaw * gain,
+            head_roll=self.head_roll * gain,
+            head_x=self.head_x * gain,
+            head_y=self.head_y * gain,
+            head_z=self.head_z * gain,
+            antenna_left=self.antenna_left * gain,
+            antenna_right=self.antenna_right * gain,
+        )
+
+    def clipped(self, caps: "PoseOffset") -> "PoseOffset":
+        """Clamp every channel to ``[-cap, +cap]`` per ``caps``.
+
+        Caps are interpreted as absolute magnitudes; sign is ignored. A cap
+        of ``0`` zeroes the channel (useful for disabling translation on
+        layers that should only rotate the head).
+        """
+        return PoseOffset(
+            head_pitch=_clamp(self.head_pitch, abs(caps.head_pitch)),
+            head_yaw=_clamp(self.head_yaw, abs(caps.head_yaw)),
+            head_roll=_clamp(self.head_roll, abs(caps.head_roll)),
+            head_x=_clamp(self.head_x, abs(caps.head_x)),
+            head_y=_clamp(self.head_y, abs(caps.head_y)),
+            head_z=_clamp(self.head_z, abs(caps.head_z)),
+            antenna_left=_clamp(self.antenna_left, abs(caps.antenna_left)),
+            antenna_right=_clamp(self.antenna_right, abs(caps.antenna_right)),
+        )
+
+    def with_(self, **changes: float) -> "PoseOffset":
+        """Convenience: return a copy with the named channels replaced."""
+        return replace(self, **changes)
+
+
+NEUTRAL = PoseOffset()
+
+
+def _clamp(value: float, cap: float) -> float:
+    if cap <= 0:
+        return 0.0
+    if value > cap:
+        return cap
+    if value < -cap:
+        return -cap
+    return value

--- a/src/motion/wobbler.py
+++ b/src/motion/wobbler.py
@@ -1,0 +1,236 @@
+"""L1 audio-reactive wobble — secondary motion locked to assistant speech.
+
+This is the "alive while talking" layer. It consumes PCM16 audio chunks
+fed in by the bridge, tracks a smoothed loudness envelope, and drives a
+small bank of detuned sinusoidal oscillators on top. The composer asks
+for ``current_offset()`` on each tick and adds the result to the pose.
+
+There is no LLM or gesture allow-list here: the wobbler can't pick a
+"wrong" move because it can't pick at all — it only modulates.
+
+Loudness model
+--------------
+Each ``feed()`` chunk's RMS is converted to a normalised ``[0, 1]``
+loudness using a fixed reference level. The envelope tracks the loudness
+with a fast attack and a slower exponential decay, so silence → no motion
+within a few hundred milliseconds even if ``feed()`` keeps being called
+with quiet chunks. ``reset()`` zeros the envelope immediately for
+barge-in (plan §7 rule 4).
+
+Oscillators
+-----------
+Six independent sinusoids at slightly detuned frequencies, one per output
+channel (head pitch / yaw / roll / z, antenna left / right). Each is
+driven by the wall clock so motion stays continuous across feeds. The
+envelope multiplies the amplitude of every oscillator uniformly — quiet
+audio = small wobble, loud audio = full-amplitude wobble.
+
+Per-channel amplitudes are conservative; the composer also has its own
+final-output safety cap.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from motion.types import NEUTRAL, PoseOffset
+
+_DEG = math.pi / 180.0
+
+
+# Reference loudness — chosen so a "comfortable conversational" PCM16 stream
+# normalises to ~0.7. Empirical; tune in Phase 6 with a hardware mic loop.
+_REFERENCE_RMS = 6500.0
+
+# Loudness envelope smoothing. Attack snaps up so the wobble responds to
+# the first loud sample; decay is slow enough that motion doesn't stutter
+# between syllables but fast enough to die during silence.
+_ATTACK_SECONDS = 0.05
+_DECAY_SECONDS = 0.35
+
+
+@dataclass(frozen=True)
+class _Oscillator:
+    """One sinusoidal driver feeding one channel."""
+
+    channel: str  # PoseOffset field name
+    frequency_hz: float
+    peak_amplitude: float  # SI units (rad or m) at envelope = 1.0
+    phase_offset: float = 0.0
+
+
+# Six oscillators, slightly detuned so the channels never line up into a
+# single big "lurch". Amplitudes are conservative — caps in plan §9.
+_DEFAULT_OSCILLATORS = (
+    _Oscillator("head_pitch", frequency_hz=2.0, peak_amplitude=3.0 * _DEG),
+    _Oscillator("head_yaw", frequency_hz=1.1, peak_amplitude=2.0 * _DEG, phase_offset=math.pi / 3),
+    _Oscillator("head_roll", frequency_hz=1.3, peak_amplitude=1.0 * _DEG, phase_offset=math.pi / 5),
+    _Oscillator("head_z", frequency_hz=2.4, peak_amplitude=0.0025, phase_offset=math.pi / 7),
+    _Oscillator("antenna_left", frequency_hz=1.6, peak_amplitude=8.0 * _DEG),
+    _Oscillator(
+        "antenna_right",
+        frequency_hz=1.7,
+        peak_amplitude=8.0 * _DEG,
+        phase_offset=math.pi,  # antiphase with left so they alternate
+    ),
+)
+
+
+class AudioWobbler:
+    """Audio-amplitude-modulated additive offset source.
+
+    Wire as the composer's wobble source:
+
+        composer.set_wobble_source(wobbler.current_offset)
+
+    Feed PCM16 mono chunks (any sample rate) from the assistant audio path,
+    and call :meth:`reset` on barge-in.
+    """
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int = 24000,
+        clock: Callable[[], float] = time.monotonic,
+        oscillators=_DEFAULT_OSCILLATORS,
+        reference_rms: float = _REFERENCE_RMS,
+    ) -> None:
+        if sample_rate <= 0:
+            raise ValueError(f"sample_rate must be positive, got {sample_rate!r}")
+        self._sample_rate = sample_rate
+        self._clock = clock
+        self._oscillators = tuple(oscillators)
+        self._reference_rms = reference_rms
+
+        self._lock = threading.Lock()
+        self._envelope = 0.0
+        self._last_update_at: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    # Audio ingestion
+    # ------------------------------------------------------------------
+
+    def feed(self, pcm_bytes: bytes) -> None:
+        """Update the loudness envelope from one PCM16 chunk."""
+        if not pcm_bytes:
+            return
+        loudness = self._chunk_loudness(pcm_bytes)
+        if loudness <= 0.0:
+            # Silent chunk: just decay; don't pull envelope up to zero.
+            now = self._clock()
+            with self._lock:
+                self._decay_to_now_locked(now)
+            return
+        now = self._clock()
+        with self._lock:
+            self._follow_envelope_locked(now, loudness)
+
+    def reset(self) -> None:
+        """Zero the envelope immediately. Used on barge-in."""
+        with self._lock:
+            self._envelope = 0.0
+            self._last_update_at = self._clock()
+
+    # ------------------------------------------------------------------
+    # Composer-facing source
+    # ------------------------------------------------------------------
+
+    def current_offset(self) -> PoseOffset:
+        """Return the current additive pose offset.
+
+        Decays the envelope toward the current clock first so the wobble
+        dies cleanly during silence even if no ``feed()`` calls arrive.
+        """
+        now = self._clock()
+        with self._lock:
+            self._decay_to_now_locked(now)
+            envelope = self._envelope
+
+        # Below ~0.1% of full envelope the per-channel offsets are sub-mrad —
+        # not worth computing oscillators for and visually identical to
+        # neutral. The cutoff also ensures the wobble dies cleanly during
+        # silence even though exponential decay never literally reaches 0.
+        if envelope <= 1e-3:
+            return NEUTRAL
+
+        accum = {
+            "head_pitch": 0.0,
+            "head_yaw": 0.0,
+            "head_roll": 0.0,
+            "head_x": 0.0,
+            "head_y": 0.0,
+            "head_z": 0.0,
+            "antenna_left": 0.0,
+            "antenna_right": 0.0,
+        }
+        for osc in self._oscillators:
+            phase = 2.0 * math.pi * osc.frequency_hz * now + osc.phase_offset
+            accum[osc.channel] += envelope * osc.peak_amplitude * math.sin(phase)
+        return PoseOffset(**accum)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _chunk_loudness(self, pcm_bytes: bytes) -> float:
+        """Normalised loudness in ``[0, 1]`` from one PCM16 chunk.
+
+        Uses RMS divided by a fixed reference level, soft-clipped at 1.0.
+        """
+        # PCM16 little-endian ≡ ``<i2``. Drop a trailing odd byte if the
+        # backend sent half a sample (defensive — should never happen).
+        usable = len(pcm_bytes) - (len(pcm_bytes) % 2)
+        if usable < 2:
+            return 0.0
+        sample_count = usable // 2
+        samples = struct.unpack(f"<{sample_count}h", pcm_bytes[:usable])
+        # Mean of squares without numpy — chunks are small (<= 80ms ≈ 1920
+        # samples at 24kHz) so a Python loop is fine.
+        sum_sq = 0.0
+        for s in samples:
+            sum_sq += s * s
+        rms = math.sqrt(sum_sq / sample_count)
+        loudness = rms / self._reference_rms
+        if loudness > 1.0:
+            return 1.0
+        if loudness < 0.0:  # impossible but cheap
+            return 0.0
+        return loudness
+
+    def _follow_envelope_locked(self, now: float, target: float) -> None:
+        """Standard attack/release envelope follower.
+
+        When the envelope is effectively zero (first feed ever, or after
+        silence has decayed it) we snap to ``target`` so the wobble responds
+        instantly to the leading edge of an utterance rather than waiting
+        for the attack constant to ramp from zero.
+        """
+        if self._envelope <= 1e-3:
+            self._envelope = target
+            self._last_update_at = now
+            return
+        if self._last_update_at is None:
+            self._envelope = target
+            self._last_update_at = now
+            return
+        dt = max(now - self._last_update_at, 1e-6)
+        tau = _ATTACK_SECONDS if target > self._envelope else _DECAY_SECONDS
+        alpha = 1.0 - math.exp(-dt / tau)
+        self._envelope += (target - self._envelope) * alpha
+        self._last_update_at = now
+
+    def _decay_to_now_locked(self, now: float) -> None:
+        """Pull the envelope toward zero based on time since the last update."""
+        if self._last_update_at is None:
+            self._last_update_at = now
+            return
+        dt = now - self._last_update_at
+        if dt <= 0:
+            return
+        self._envelope *= math.exp(-dt / _DECAY_SECONDS)
+        self._last_update_at = now

--- a/src/robot_kids_teacher.py
+++ b/src/robot_kids_teacher.py
@@ -109,7 +109,54 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional max session length in seconds.",
     )
+    parser.add_argument(
+        "--motion-layers",
+        default=None,
+        help=(
+            "Motion-director layer set: 'full' (default), 'none', or comma "
+            "list from {wobble,gestures,tracking}. Overrides the env var "
+            "KIDS_TEACHER_MOTION_LAYERS."
+        ),
+    )
     return parser
+
+
+_MOTION_LAYERS_ENV_VAR = "KIDS_TEACHER_MOTION_LAYERS"
+
+
+def _resolve_motion_layers_spec(cli_value: Optional[str]) -> Optional[str]:
+    """Pick the motion-layers spec from CLI > env > default ('full')."""
+    if cli_value is not None and cli_value.strip():
+        return cli_value
+    raw = os.environ.get(_MOTION_LAYERS_ENV_VAR, "").strip()
+    if raw:
+        return raw
+    return None  # parse_layers(None) -> ALL_LAYERS
+
+
+def _maybe_make_motion_stack(
+    robot_controller: Any, *, layers_spec: Optional[str], audio_sample_rate: int
+) -> Optional[Any]:
+    """Construct a :class:`MotionStack` unless layers spec is ``"none"``."""
+    from motion.stack import MotionStack, MotionStackConfig, parse_layers
+
+    layers = parse_layers(layers_spec)
+    if not layers:
+        logger.info(
+            "[robot_kids_teacher] motion director disabled (layers=none); "
+            "falling back to legacy speak/listen/idle"
+        )
+        return None
+    logger.info(
+        "[robot_kids_teacher] motion director enabled with layers=%s",
+        sorted(layers),
+    )
+    return MotionStack(
+        robot_controller=robot_controller,
+        config=MotionStackConfig(
+            layers=layers, audio_sample_rate=audio_sample_rate
+        ),
+    )
 
 
 def _build_mic_reader(
@@ -177,6 +224,7 @@ async def _run_session_async(
     mic_reader: Callable[[], Optional[bytes]],
     provider: str,
     camera_worker: Any,
+    motion_layers_spec: Optional[str] = None,
 ) -> None:
     from kids_teacher_flow import build_robot_hooks
 
@@ -195,14 +243,21 @@ async def _run_session_async(
         present_names=present_names,
     )
 
-    hooks = build_robot_hooks(robot_controller)
+    motion_stack = _maybe_make_motion_stack(
+        robot_controller,
+        layers_spec=_resolve_motion_layers_spec(motion_layers_spec),
+        audio_sample_rate=24000,
+    )
+    hooks = build_robot_hooks(robot_controller, motion_stack=motion_stack)
     backend_factory = _build_backend_factory(provider, camera_worker)
     video_pump_factory = (
         _make_video_pump_factory(camera_worker)
         if camera_worker is not None
         else None
     )
-    gaze_loop_factory = _maybe_make_gaze_loop_factory(camera_worker, provider)
+    gaze_loop_factory = _maybe_make_gaze_loop_factory(
+        camera_worker, provider, motion_stack=motion_stack
+    )
     face_rec_loop_factory = _maybe_build_face_rec_loop_factory(
         camera_worker=camera_worker,
         provider=provider,
@@ -303,7 +358,10 @@ def _gaze_follow_enabled() -> bool:
 
 
 def _maybe_make_gaze_loop_factory(
-    camera_worker: Any, provider: str
+    camera_worker: Any,
+    provider: str,
+    *,
+    motion_stack: Optional[Any] = None,
 ) -> Optional[Callable[[Any, asyncio.Event], Awaitable[None]]]:
     """Return a gaze-loop factory for ``provider=gemini`` only.
 
@@ -344,19 +402,20 @@ def _maybe_make_gaze_loop_factory(
             "no targets will be published until dlib is installed"
         )
 
-    return _make_gaze_loop_factory(camera_worker)
+    return _make_gaze_loop_factory(camera_worker, motion_stack=motion_stack)
 
 
 def _make_gaze_loop_factory(
     camera_worker: Any,
+    *,
+    motion_stack: Optional[Any] = None,
 ) -> Callable[[Any, asyncio.Event], Awaitable[None]]:
     """Return a coroutine factory that runs the FaceTracker loop.
 
-    A default debug-level logging subscriber is attached so the
-    ``gaze_target`` channel is observable even before the motion director
-    ships. The motion director will register its own subscriber through
-    ``FaceTracker.subscribe`` when it lands; this factory does not import
-    or depend on it.
+    When ``motion_stack`` is provided, the motion director's
+    :class:`FaceOffsetMixer` is attached as the L3 subscriber. Otherwise a
+    debug-level logging subscriber is attached so the ``gaze_target``
+    channel stays observable.
     """
     from face_tracker import FaceTracker
 
@@ -365,18 +424,38 @@ def _make_gaze_loop_factory(
     async def _loop(handler: Any, stop_event: asyncio.Event) -> None:
         tracker = FaceTracker(camera_worker, child_name=child_name)
 
-        def _log_target(target: Optional[tuple[float, float]]) -> None:
-            if target is None:
-                logger.debug("[face_tracker] gaze_target=None")
-            else:
-                logger.debug(
-                    "[face_tracker] gaze_target=(%.3f, %.3f)", target[0], target[1]
+        if motion_stack is not None:
+            try:
+                motion_stack.attach_face_tracker(tracker)
+            except Exception as exc:
+                logger.warning(
+                    "[robot_kids_teacher] motion_stack.attach_face_tracker raised: %s",
+                    exc,
                 )
+        else:
+            def _log_target(target: Optional[tuple[float, float]]) -> None:
+                if target is None:
+                    logger.debug("[face_tracker] gaze_target=None")
+                else:
+                    logger.debug(
+                        "[face_tracker] gaze_target=(%.3f, %.3f)",
+                        target[0],
+                        target[1],
+                    )
 
-        tracker.subscribe(_log_target)
+            tracker.subscribe(_log_target)
+
         try:
             await tracker.run(stop_event)
         finally:
+            if motion_stack is not None:
+                try:
+                    motion_stack.detach_face_tracker()
+                except Exception as exc:
+                    logger.debug(
+                        "[robot_kids_teacher] motion_stack.detach_face_tracker raised: %s",
+                        exc,
+                    )
             await tracker.stop()
 
     return _loop
@@ -685,6 +764,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                         mic_reader,
                         provider,
                         camera_worker,
+                        motion_layers_spec=args.motion_layers,
                     )
                 )
             finally:

--- a/src/robot_teacher.py
+++ b/src/robot_teacher.py
@@ -614,6 +614,60 @@ class RobotController:
 
         return False
 
+    # ── Streaming pose tick (motion-director sink) ────────────────────────────
+
+    def apply_pose(
+        self,
+        *,
+        head_pitch: float = 0.0,
+        head_yaw: float = 0.0,
+        head_roll: float = 0.0,
+        head_x: float = 0.0,
+        head_y: float = 0.0,
+        head_z: float = 0.0,
+        antenna_left: float = 0.0,
+        antenna_right: float = 0.0,
+        duration: float = 0.05,
+    ) -> bool:
+        """Push a single pose frame to the SDK. Drops the frame if the
+        motion lock is contended.
+
+        Designed for the motion-director composer: called at ~30 Hz with
+        durations matching the tick period. Bypasses the cooldown / retry
+        logic in :meth:`_goto_target_safe` because at this cadence we'd
+        rather drop a stale frame than queue or back off.
+
+        All values are SI units (radians, metres).
+
+        Returns True if the SDK call ran, False if the frame was dropped.
+        """
+        if not self._motion_lock.acquire(timeout=max(duration * 0.5, 0.005)):
+            return False
+        try:
+            head = create_head_pose(
+                pitch=head_pitch,
+                yaw=head_yaw,
+                roll=head_roll,
+                x=head_x,
+                y=head_y,
+                z=head_z,
+            )
+            antennas = np.array([antenna_left, antenna_right], dtype=float)
+            self._mini.goto_target(
+                head=head,
+                antennas=antennas,
+                duration=max(duration, 1e-3),
+                method="minjerk",
+            )
+            return True
+        except Exception as exc:
+            # Streaming poses fire at 30 Hz; one bad frame should not log
+            # at warning level. Drop silently — the composer keeps ticking.
+            logger.debug("[RobotController] apply_pose dropped frame: %s", exc)
+            return False
+        finally:
+            self._motion_lock.release()
+
     # ── Idle: slow head sway, relaxed antennas ─────────────────────────────────
 
     def idle(self):

--- a/tests/test_kids_teacher_backend.py
+++ b/tests/test_kids_teacher_backend.py
@@ -349,6 +349,125 @@ def test_normalize_response_done() -> None:
     }
 
 
+def test_normalize_function_call_arguments_done() -> None:
+    event = OpenAIRealtimeBackend._normalize_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "call_id": "call_abc",
+            "name": "play_gesture",
+            "arguments": '{"name": "nod_encourage"}',
+        }
+    )
+    assert event == {
+        "type": "tool.call",
+        "call_id": "call_abc",
+        "name": "play_gesture",
+        "arguments": '{"name": "nod_encourage"}',
+    }
+
+
+def test_normalize_function_call_arguments_done_with_missing_fields() -> None:
+    """Missing fields should normalize to empty strings, not None or KeyError."""
+    event = OpenAIRealtimeBackend._normalize_event(
+        {"type": "response.function_call_arguments.done"}
+    )
+    assert event == {
+        "type": "tool.call",
+        "call_id": "",
+        "name": "",
+        "arguments": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# additional_tools — motion-director tool injection
+# ---------------------------------------------------------------------------
+
+
+def test_build_session_payload_appends_additional_tools() -> None:
+    profile = _make_profile(tools=("legacy_tool",))
+    extra = [
+        {
+            "type": "function",
+            "name": "play_gesture",
+            "description": "...",
+            "parameters": {"type": "object"},
+        }
+    ]
+    payload = build_session_payload(_make_config(profile), additional_tools=extra)
+    names = [t["name"] for t in payload["tools"]]
+    assert names == ["legacy_tool", "play_gesture"]
+
+
+def test_build_session_payload_does_not_duplicate_overlapping_tool_names() -> None:
+    profile = _make_profile(tools=("play_gesture",))
+    extra = [
+        {"type": "function", "name": "play_gesture", "description": "x"},
+        {"type": "function", "name": "stop_motion", "description": "y"},
+    ]
+    payload = build_session_payload(_make_config(profile), additional_tools=extra)
+    names = [t["name"] for t in payload["tools"]]
+    assert names == ["play_gesture", "stop_motion"]
+
+
+# ---------------------------------------------------------------------------
+# send_tool_response — function_call_output dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_tool_response_creates_function_call_output_item() -> None:
+    """Backend must ack tool calls with the matching call_id + string output."""
+    items_created: list[dict] = []
+
+    class _StubItem:
+        async def create(self, *, item: dict) -> None:
+            items_created.append(item)
+
+    class _StubConversation:
+        def __init__(self) -> None:
+            self.item = _StubItem()
+
+    backend = OpenAIRealtimeBackend(client_factory=lambda: object())
+    backend._connection = SimpleNamespace(conversation=_StubConversation())  # type: ignore[attr-defined]
+
+    await backend.send_tool_response("call_abc", '{"ok": true}')
+
+    assert items_created == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_abc",
+            "output": '{"ok": true}',
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_tool_response_no_op_without_connection() -> None:
+    backend = OpenAIRealtimeBackend(client_factory=lambda: object())
+    # Must not raise even though _connection is None.
+    await backend.send_tool_response("call_abc", "{}")
+
+
+@pytest.mark.asyncio
+async def test_send_tool_response_no_op_when_call_id_blank() -> None:
+    items_created: list[dict] = []
+
+    class _StubItem:
+        async def create(self, *, item: dict) -> None:
+            items_created.append(item)
+
+    backend = OpenAIRealtimeBackend(client_factory=lambda: object())
+    backend._connection = SimpleNamespace(  # type: ignore[attr-defined]
+        conversation=SimpleNamespace(item=_StubItem())
+    )
+
+    await backend.send_tool_response("", "{}")
+
+    # Blank call_id is dropped without hitting the SDK.
+    assert items_created == []
+
+
 def test_normalize_unknown_event_returns_none() -> None:
     # Acknowledgements and other unhandled events are silently dropped.
     assert OpenAIRealtimeBackend._normalize_event({"type": "session.created"}) is None

--- a/tests/test_kids_teacher_realtime.py
+++ b/tests/test_kids_teacher_realtime.py
@@ -610,3 +610,282 @@ async def test_session_reconnecting_publishes_reconnecting_status_no_fallback():
 
     await backend.end_stream()
     await run_task
+
+
+# ---------------------------------------------------------------------------
+# Behavior 12: tool.call dispatch (motion-director plumbing)
+# ---------------------------------------------------------------------------
+
+
+class _ToolHooks(FakeHooks):
+    """FakeHooks + a recording handle_tool_call."""
+
+    def __init__(self, *, return_value: Optional[str] = '{"ok": true}',
+                 raise_exc: Optional[Exception] = None) -> None:
+        super().__init__()
+        self.tool_calls: List[tuple] = []
+        self._return_value = return_value
+        self._raise_exc = raise_exc
+
+    def handle_tool_call(
+        self, call_id: str, name: str, arguments: str
+    ) -> Optional[str]:
+        self.tool_calls.append((call_id, name, arguments))
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._return_value
+
+
+async def test_tool_call_event_dispatched_to_hook_and_acked() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _ToolHooks(return_value='{"ok": true, "detail": "playing"}')
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "call_xyz",
+            "name": "play_gesture",
+            "arguments": '{"name": "nod_encourage"}',
+        }
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.tool_calls == [
+        ("call_xyz", "play_gesture", '{"name": "nod_encourage"}')
+    ]
+    assert backend.tool_responses == [
+        ("call_xyz", '{"ok": true, "detail": "playing"}')
+    ]
+
+
+async def test_tool_call_without_handle_tool_call_hook_is_ignored() -> None:
+    """Hooks that don't expose handle_tool_call must not crash the handler."""
+    backend = FakeRealtimeBackend()
+    hooks = FakeHooks()  # no handle_tool_call
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "call_xyz",
+            "name": "play_gesture",
+            "arguments": "{}",
+        }
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert backend.tool_responses == []
+
+
+async def test_tool_call_hook_returning_none_skips_ack() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _ToolHooks(return_value=None)
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "call_xyz",
+            "name": "play_gesture",
+            "arguments": "{}",
+        }
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.tool_calls == [("call_xyz", "play_gesture", "{}")]
+    assert backend.tool_responses == []
+
+
+async def test_tool_call_hook_exception_is_swallowed() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _ToolHooks(raise_exc=RuntimeError("hook boom"))
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "call_xyz",
+            "name": "play_gesture",
+            "arguments": "{}",
+        }
+    )
+    await asyncio.sleep(0.01)
+
+    # Subsequent events should still be processed — the handler didn't die.
+    await backend.push_event(
+        {"type": "input.speech_started"}
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    # No ack was sent (hook raised before returning a payload).
+    assert backend.tool_responses == []
+
+
+async def test_tool_call_event_with_blank_call_id_skips_ack() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _ToolHooks(return_value='{"ok": true}')
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "",
+            "name": "play_gesture",
+            "arguments": "{}",
+        }
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    # Hook still fires (so the side-effect happens) but no ack is shipped.
+    assert hooks.tool_calls == [("", "play_gesture", "{}")]
+    assert backend.tool_responses == []
+
+
+async def test_tool_call_event_with_non_string_arguments_normalizes_to_empty() -> None:
+    """Defensive: if the backend ever ships non-string args, hand them along
+    as an empty string rather than letting a TypeError reach the model."""
+    backend = FakeRealtimeBackend()
+    hooks = _ToolHooks()
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event(
+        {
+            "type": "tool.call",
+            "call_id": "call_xyz",
+            "name": "play_gesture",
+            "arguments": {"name": "nod_encourage"},  # dict instead of str
+        }
+    )
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.tool_calls == [("call_xyz", "play_gesture", "")]
+
+
+# ---------------------------------------------------------------------------
+# Behavior 13: VAD edges forwarded to optional hooks (motion-director)
+# ---------------------------------------------------------------------------
+
+
+class _VadHooks(FakeHooks):
+    def __init__(self, *, raise_on_started: bool = False) -> None:
+        super().__init__()
+        self.speech_started_calls = 0
+        self.speech_stopped_calls = 0
+        self._raise_on_started = raise_on_started
+
+    def on_speech_started(self) -> None:
+        self.speech_started_calls += 1
+        if self._raise_on_started:
+            raise RuntimeError("hook boom")
+
+    def on_speech_stopped(self) -> None:
+        self.speech_stopped_calls += 1
+
+
+async def test_speech_started_event_forwards_to_hook() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _VadHooks()
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event({"type": "input.speech_started"})
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.speech_started_calls == 1
+
+
+async def test_speech_stopped_event_forwards_to_hook() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _VadHooks()
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event({"type": "input.speech_stopped"})
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.speech_stopped_calls == 1
+
+
+async def test_vad_edges_no_op_when_hook_missing() -> None:
+    """Hooks without on_speech_started/stopped must not crash the loop."""
+    backend = FakeRealtimeBackend()
+    hooks = FakeHooks()  # no VAD methods
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event({"type": "input.speech_started"})
+    await backend.push_event({"type": "input.speech_stopped"})
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+
+async def test_vad_hook_exception_is_swallowed() -> None:
+    backend = FakeRealtimeBackend()
+    hooks = _VadHooks(raise_on_started=True)
+    handler = _handler(backend, hooks)
+
+    await handler.start()
+    run_task = asyncio.create_task(handler.run())
+    await asyncio.sleep(0.01)
+
+    await backend.push_event({"type": "input.speech_started"})
+    await asyncio.sleep(0.01)
+    # The handler must still process subsequent events.
+    await backend.push_event({"type": "input.speech_stopped"})
+    await asyncio.sleep(0.01)
+    await backend.end_stream()
+    await run_task
+
+    assert hooks.speech_started_calls == 1
+    assert hooks.speech_stopped_calls == 1

--- a/tests/test_kids_teacher_robot_bridge.py
+++ b/tests/test_kids_teacher_robot_bridge.py
@@ -847,3 +847,205 @@ def test_default_recovery_cue_swallows_missing_robot_teacher(monkeypatch):
             __builtins__["__import__"] = real_import
         else:
             __builtins__.__import__ = real_import  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Motion-stack integration (motion-director wiring)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMotionStack:
+    """Minimal MotionStack stand-in that records every bridge-facing call."""
+
+    def __init__(
+        self,
+        *,
+        tool_payload: Optional[str] = '{"ok": true}',
+        tool_raises: bool = False,
+    ) -> None:
+        self.calls: List[str] = []
+        self.audio_chunks: List[bytes] = []
+        self.tool_calls: List[Tuple[str, str, str]] = []
+        self.tool_payload = tool_payload
+        self.tool_raises = tool_raises
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start(self) -> None:
+        self.start_calls += 1
+
+    def stop(self, timeout: float = 1.0) -> None:
+        self.stop_calls += 1
+
+    def feed_assistant_audio(self, chunk: bytes) -> None:
+        self.audio_chunks.append(chunk)
+
+    def enter_assistant_speech(self) -> None:
+        self.calls.append("enter_assistant_speech")
+
+    def exit_assistant_speech(self) -> None:
+        self.calls.append("exit_assistant_speech")
+
+    def enter_child_speech(self) -> None:
+        self.calls.append("enter_child_speech")
+
+    def exit_child_speech(self) -> None:
+        self.calls.append("exit_child_speech")
+
+    def set_idle(self) -> None:
+        self.calls.append("set_idle")
+
+    def handle_tool_call(self, call_id: str, name: str, arguments: str) -> Optional[str]:
+        self.tool_calls.append((call_id, name, arguments))
+        if self.tool_raises:
+            raise RuntimeError("stack boom")
+        return self.tool_payload
+
+
+def _make_hooks_with_stack(stack):
+    robot = FakeRobotController()
+    recorder = RecordingPlayChunk()
+    hooks = KidsTeacherRobotHooks(
+        robot_controller=robot,
+        sample_rate=24000,
+        play_chunk=recorder,
+        motion_stack=stack,
+    )
+    return hooks, robot, recorder
+
+
+def test_motion_stack_replaces_legacy_speak_listen_idle_calls():
+    """When a stack is wired the bridge must NOT call robot.speak/listen/idle —
+    the composer is the sole motor driver."""
+    stack = _RecordingMotionStack()
+    hooks, robot, _ = _make_hooks_with_stack(stack)
+
+    hooks.start_assistant_playback(b"\x00\x01")
+    hooks.stop_assistant_playback()
+    hooks.publish_status(_status(SessionStatus.IDLE))
+
+    # The legacy animation methods must not appear in the call log.
+    legacy = {"speak", "listen", "idle"}
+    assert legacy.isdisjoint(set(robot.calls))
+
+
+def test_motion_stack_enter_assistant_on_first_chunk_only():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.start_assistant_playback(b"\x00\x01")
+    hooks.start_assistant_playback(b"\x02\x03")
+    hooks.start_assistant_playback(b"\x04\x05")
+
+    # Three chunks fed; only one enter_assistant_speech.
+    assert stack.audio_chunks == [b"\x00\x01", b"\x02\x03", b"\x04\x05"]
+    assert stack.calls.count("enter_assistant_speech") == 1
+
+
+def test_motion_stack_exit_assistant_on_stop():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.start_assistant_playback(b"\x00\x01")
+    hooks.stop_assistant_playback()
+
+    assert stack.calls[-1] == "exit_assistant_speech"
+
+
+def test_motion_stack_status_listening_routes_to_exit_assistant():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.publish_status(_status(SessionStatus.LISTENING))
+    assert stack.calls == ["exit_assistant_speech"]
+
+
+def test_motion_stack_status_speaking_routes_to_enter_assistant():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.publish_status(_status(SessionStatus.SPEAKING))
+    assert stack.calls == ["enter_assistant_speech"]
+
+
+def test_motion_stack_status_idle_and_ended_route_to_set_idle():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.publish_status(_status(SessionStatus.IDLE))
+    hooks.publish_status(_status(SessionStatus.ENDED))
+    hooks.publish_status(_status(SessionStatus.ERROR))
+
+    assert stack.calls == ["set_idle", "set_idle", "set_idle"]
+
+
+def test_motion_stack_reconnecting_clears_speaking_and_exits_assistant():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.start_assistant_playback(b"\x00\x01")
+    stack.calls.clear()  # ignore the enter call
+
+    hooks.publish_status(_status(SessionStatus.RECONNECTING, detail="testing"))
+
+    assert "exit_assistant_speech" in stack.calls
+
+
+def test_on_speech_started_routes_to_enter_child_speech():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.on_speech_started()
+
+    assert stack.calls == ["enter_child_speech"]
+
+
+def test_on_speech_stopped_routes_to_exit_child_speech():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    hooks.on_speech_stopped()
+
+    assert stack.calls == ["exit_child_speech"]
+
+
+def test_handle_tool_call_routes_to_stack_and_returns_payload():
+    stack = _RecordingMotionStack(tool_payload='{"ok": true, "detail": "ok"}')
+    hooks, _, _ = _make_hooks_with_stack(stack)
+
+    payload = hooks.handle_tool_call("c1", "play_gesture", '{"name": "nod"}')
+
+    assert stack.tool_calls == [("c1", "play_gesture", '{"name": "nod"}')]
+    assert payload == '{"ok": true, "detail": "ok"}'
+
+
+def test_handle_tool_call_returns_none_when_no_motion_stack():
+    hooks, _, _ = _make_hooks()
+    assert hooks.handle_tool_call("c1", "play_gesture", "{}") is None
+
+
+def test_handle_tool_call_swallows_stack_exception_and_returns_none():
+    stack = _RecordingMotionStack(tool_raises=True)
+    hooks, _, _ = _make_hooks_with_stack(stack)
+    payload = hooks.handle_tool_call("c1", "play_gesture", "{}")
+    assert payload is None
+
+
+def test_motion_stack_lifecycle_called_on_start_and_stop():
+    stack = _RecordingMotionStack()
+    hooks, _, _ = _make_hooks_with_stack(stack)
+    hooks.start()
+    try:
+        assert stack.start_calls == 1
+    finally:
+        hooks.stop()
+    assert stack.stop_calls >= 1
+
+
+def test_motion_stack_absent_preserves_legacy_speak_listen_calls():
+    """Smoke: no regression for the kill-switch path."""
+    hooks, robot, _ = _make_hooks()  # no motion_stack
+    hooks.start_assistant_playback(b"\x00\x01")
+    hooks.stop_assistant_playback()
+    assert "speak" in robot.calls
+    assert "listen" in robot.calls

--- a/tests/test_motion_composer.py
+++ b/tests/test_motion_composer.py
@@ -1,0 +1,310 @@
+"""Unit tests for :mod:`motion.composer`."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from typing import List, Tuple
+
+import pytest
+
+from motion.composer import (
+    DEFAULT_SAFETY_CAPS,
+    DEFAULT_STATE_POSES,
+    MovementComposer,
+)
+from motion.library import Clip
+from motion.types import NEUTRAL, PoseOffset
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[PoseOffset, float]] = []
+
+    def __call__(self, offset: PoseOffset, period: float) -> None:
+        self.calls.append((offset, period))
+
+
+def _const_clip(value: PoseOffset, duration: float = 1.0, lane: str = "affect") -> Clip:
+    return Clip(name="test", duration=duration, lane=lane, pose_at=lambda t: value)  # noqa: ARG005
+
+
+def _make(
+    *, clock: _FakeClock | None = None, tick_hz: float = 30.0
+) -> Tuple[MovementComposer, _FakeClock, _RecordingSink]:
+    clock = clock or _FakeClock()
+    sink = _RecordingSink()
+    composer = MovementComposer(pose_sink=sink, tick_hz=tick_hz, clock=clock)
+    return composer, clock, sink
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_non_positive_tick_hz():
+    with pytest.raises(ValueError):
+        MovementComposer(pose_sink=_RecordingSink(), tick_hz=0.0)
+    with pytest.raises(ValueError):
+        MovementComposer(pose_sink=_RecordingSink(), tick_hz=-5.0)
+
+
+def test_default_state_is_idle_and_idle_pose_is_neutral():
+    composer, _, _ = _make()
+    assert composer.compose_pose(0.0) == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# State poses
+# ---------------------------------------------------------------------------
+
+
+def test_listen_state_yields_listen_roll():
+    composer, _, _ = _make()
+    composer.set_state("listen")
+    pose = composer.compose_pose(0.0)
+    assert math.isclose(pose.head_roll, DEFAULT_STATE_POSES["listen"].head_roll)
+
+
+def test_unknown_state_falls_back_to_idle():
+    composer, _, _ = _make()
+    composer.set_state("not_a_state")
+    assert composer.compose_pose(0.0) == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# L2 clip
+# ---------------------------------------------------------------------------
+
+
+def test_play_clip_contributes_to_pose():
+    composer, clock, _ = _make()
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.1)))
+    assert composer.compose_pose(clock.now).head_pitch == pytest.approx(0.1)
+
+
+def test_clip_expires_after_duration_and_returns_neutral():
+    composer, clock, _ = _make()
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.1), duration=1.0))
+    clock.advance(1.0)
+    pose = composer.compose_pose(clock.now)
+    assert pose == NEUTRAL
+
+
+def test_play_clip_replaces_active_clip():
+    composer, clock, _ = _make()
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.1), duration=10.0))
+    clock.advance(0.5)
+    composer.play_clip(_const_clip(PoseOffset(head_yaw=0.2), duration=10.0))
+    pose = composer.compose_pose(clock.now)
+    assert pose.head_pitch == 0.0
+    assert pose.head_yaw == pytest.approx(0.2)
+
+
+def test_cancel_clip_drops_active_clip():
+    composer, clock, _ = _make()
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.1), duration=10.0))
+    composer.cancel_clip()
+    assert composer.compose_pose(clock.now) == NEUTRAL
+
+
+def test_clip_pose_at_exception_drops_clip():
+    """A misbehaving clip must not crash the composer thread."""
+    composer, clock, _ = _make()
+
+    def _explode(t: float) -> PoseOffset:  # noqa: ARG001
+        raise RuntimeError("kaboom")
+
+    composer.play_clip(Clip("bad", duration=1.0, lane="affect", pose_at=_explode))
+    pose = composer.compose_pose(clock.now)
+    assert pose == NEUTRAL
+    # Subsequent ticks should keep returning neutral, not re-raise.
+    assert composer.compose_pose(clock.now) == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# L1 / L3 sources
+# ---------------------------------------------------------------------------
+
+
+def test_wobble_source_adds_to_pose():
+    composer, _, _ = _make()
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=0.05))
+    assert composer.compose_pose(0.0).head_pitch == pytest.approx(0.05)
+
+
+def test_face_offset_source_adds_to_pose():
+    composer, _, _ = _make()
+    composer.set_face_offset_source(lambda: PoseOffset(head_yaw=0.07))
+    assert composer.compose_pose(0.0).head_yaw == pytest.approx(0.07)
+
+
+def test_all_layers_sum():
+    composer, clock, _ = _make()
+    composer.set_state("listen")  # base: head_roll = 15°
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.05)))
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=0.02))
+    composer.set_face_offset_source(lambda: PoseOffset(head_yaw=0.03))
+
+    pose = composer.compose_pose(clock.now)
+    assert pose.head_pitch == pytest.approx(0.07)  # clip + wobble
+    assert pose.head_yaw == pytest.approx(0.03)  # face only
+    assert pose.head_roll == pytest.approx(DEFAULT_STATE_POSES["listen"].head_roll)
+
+
+def test_source_returning_none_is_treated_as_neutral():
+    composer, _, _ = _make()
+    composer.set_wobble_source(lambda: None)  # type: ignore[arg-type,return-value]
+    assert composer.compose_pose(0.0) == NEUTRAL
+
+
+def test_source_raising_is_swallowed():
+    composer, _, _ = _make()
+
+    def _explode() -> PoseOffset:
+        raise RuntimeError("kaboom")
+
+    composer.set_wobble_source(_explode)
+    assert composer.compose_pose(0.0) == NEUTRAL
+
+
+def test_source_can_be_cleared_with_none():
+    composer, _, _ = _make()
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=0.1))
+    composer.set_wobble_source(None)
+    assert composer.compose_pose(0.0) == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Safety caps
+# ---------------------------------------------------------------------------
+
+
+def test_safety_caps_clip_runaway_source():
+    sink = _RecordingSink()
+    tight_caps = PoseOffset(head_pitch=0.05)
+    composer = MovementComposer(
+        pose_sink=sink, tick_hz=30.0, clock=_FakeClock(), safety_caps=tight_caps
+    )
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=10.0))
+    pose = composer.compose_pose(0.0)
+    assert pose.head_pitch == pytest.approx(0.05)
+
+
+def test_default_caps_allow_listen_pose():
+    """Sanity: the default cap must be loose enough for the listen state."""
+    composer, _, _ = _make()
+    composer.set_state("listen")
+    pose = composer.compose_pose(0.0)
+    assert math.isclose(pose.head_roll, DEFAULT_STATE_POSES["listen"].head_roll)
+    assert pose.head_roll <= DEFAULT_SAFETY_CAPS.head_roll
+
+
+# ---------------------------------------------------------------------------
+# tick / sink
+# ---------------------------------------------------------------------------
+
+
+def test_tick_calls_sink_with_period():
+    composer, clock, sink = _make(tick_hz=50.0)
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=0.1))
+    composer.tick()
+    assert len(sink.calls) == 1
+    offset, period = sink.calls[0]
+    assert offset.head_pitch == pytest.approx(0.1)
+    assert period == pytest.approx(1.0 / 50.0)
+
+
+def test_tick_swallows_sink_exceptions():
+    def _broken_sink(_offset: PoseOffset, _period: float) -> None:
+        raise RuntimeError("sink down")
+
+    composer = MovementComposer(pose_sink=_broken_sink, tick_hz=30.0, clock=_FakeClock())
+    # Must not raise.
+    pose = composer.tick()
+    assert pose == NEUTRAL
+
+
+def test_tick_at_uses_provided_clock_value():
+    composer, _, sink = _make()
+    composer.play_clip(_const_clip(PoseOffset(head_pitch=0.1), duration=10.0))
+    composer.tick_at(0.5)
+    composer.tick_at(11.0)  # past clip end; should be neutral now
+    assert sink.calls[0][0].head_pitch == pytest.approx(0.1)
+    assert sink.calls[1][0] == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Background loop lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_start_then_stop_runs_at_least_one_tick():
+    sink = _RecordingSink()
+    composer = MovementComposer(
+        pose_sink=sink,
+        tick_hz=200.0,  # fast so we don't slow tests
+    )
+    composer.start()
+    # Wait briefly for ticks to land.
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline and len(sink.calls) < 3:
+        time.sleep(0.01)
+    composer.stop(timeout=1.0)
+    assert len(sink.calls) >= 3
+
+
+def test_start_is_idempotent():
+    sink = _RecordingSink()
+    composer = MovementComposer(pose_sink=sink, tick_hz=200.0)
+    composer.start()
+    composer.start()  # should not spawn a second thread or raise
+    composer.stop(timeout=1.0)
+
+
+def test_stop_without_start_is_safe():
+    sink = _RecordingSink()
+    composer = MovementComposer(pose_sink=sink, tick_hz=30.0)
+    # Should not raise.
+    composer.stop(timeout=0.1)
+
+
+def test_concurrent_set_state_and_compose_is_safe():
+    """Smoke: hammer set_state from one thread while compose_pose runs."""
+    composer, clock, _ = _make()
+    composer.set_wobble_source(lambda: PoseOffset(head_pitch=0.01))
+    stop = threading.Event()
+
+    def _flipper() -> None:
+        states = ("idle", "listen", "speak")
+        i = 0
+        while not stop.is_set():
+            composer.set_state(states[i % 3])
+            i += 1
+
+    thread = threading.Thread(target=_flipper)
+    thread.start()
+    try:
+        for _ in range(500):
+            composer.compose_pose(clock.now)
+    finally:
+        stop.set()
+        thread.join(timeout=1.0)

--- a/tests/test_motion_face_offset.py
+++ b/tests/test_motion_face_offset.py
@@ -1,0 +1,351 @@
+"""Unit tests for :mod:`motion.face_offset`."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, List, Optional, Tuple
+
+import pytest
+
+from motion.face_offset import (
+    DEFAULT_GAINS,
+    MAX_PAN_RAD,
+    MAX_TILT_RAD,
+    FaceOffsetMixer,
+)
+from motion.types import NEUTRAL, PoseOffset
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+class _FakeTracker:
+    """Pollen-shaped subscribe API that lets the test push targets directly."""
+
+    def __init__(self) -> None:
+        self._subscribers: List[Callable[[Optional[Tuple[float, float]]], None]] = []
+        self.subscribe_calls = 0
+        self.unsubscribe_calls = 0
+
+    def subscribe(self, callback) -> Callable[[], None]:
+        self.subscribe_calls += 1
+        self._subscribers.append(callback)
+
+        def _unsubscribe() -> None:
+            self.unsubscribe_calls += 1
+            try:
+                self._subscribers.remove(callback)
+            except ValueError:
+                pass
+
+        return _unsubscribe
+
+    def publish(self, target: Optional[Tuple[float, float]]) -> None:
+        for cb in list(self._subscribers):
+            cb(target)
+
+
+def _make(
+    *,
+    clock: Optional[_FakeClock] = None,
+    no_target_release_s: float = 0.6,
+):
+    clock = clock or _FakeClock()
+    mixer = FaceOffsetMixer(
+        clock=clock,
+        no_target_release_s=no_target_release_s,
+    )
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    return mixer, tracker, clock
+
+
+# ---------------------------------------------------------------------------
+# Subscription lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_attach_subscribes_to_tracker():
+    mixer = FaceOffsetMixer(clock=_FakeClock())
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    assert tracker.subscribe_calls == 1
+
+
+def test_attach_is_idempotent():
+    mixer = FaceOffsetMixer(clock=_FakeClock())
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    mixer.attach(tracker)
+    assert tracker.subscribe_calls == 1
+
+
+def test_detach_unsubscribes():
+    mixer, tracker, _ = _make()
+    mixer.detach()
+    assert tracker.unsubscribe_calls == 1
+
+
+def test_detach_is_idempotent():
+    mixer, tracker, _ = _make()
+    mixer.detach()
+    mixer.detach()
+    assert tracker.unsubscribe_calls == 1
+
+
+def test_attach_to_non_tracker_raises_typeerror():
+    mixer = FaceOffsetMixer(clock=_FakeClock())
+    with pytest.raises(TypeError):
+        mixer.attach(object())
+
+
+# ---------------------------------------------------------------------------
+# Initial / no-target behavior
+# ---------------------------------------------------------------------------
+
+
+def test_no_publish_yields_neutral():
+    mixer, _, _ = _make()
+    assert mixer.current_offset() == NEUTRAL
+
+
+def test_none_publish_yields_neutral():
+    mixer, tracker, _ = _make()
+    tracker.publish(None)
+    assert mixer.current_offset() == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Direction conventions + caps
+# ---------------------------------------------------------------------------
+
+
+def test_positive_pan_yields_positive_yaw():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("child_speaking")  # gain = 1.0 to avoid scaling
+    tracker.publish((1.0, 0.0))
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(MAX_PAN_RAD)
+    assert offset.head_pitch == pytest.approx(0.0)
+
+
+def test_negative_pan_yields_negative_yaw():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("child_speaking")
+    tracker.publish((-1.0, 0.0))
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(-MAX_PAN_RAD)
+
+
+def test_positive_tilt_yields_positive_pitch():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("child_speaking")
+    tracker.publish((0.0, 1.0))
+    offset = mixer.current_offset()
+    assert offset.head_pitch == pytest.approx(MAX_TILT_RAD)
+
+
+def test_pan_beyond_unit_clamps_to_max():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("child_speaking")
+    tracker.publish((5.0, 0.0))  # outside [-1, 1]
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(MAX_PAN_RAD)
+
+
+# ---------------------------------------------------------------------------
+# Gain state
+# ---------------------------------------------------------------------------
+
+
+def test_idle_gain_scales_offset():
+    mixer, tracker, _ = _make()
+    # default state is "idle" with gain 0.7
+    tracker.publish((1.0, 0.0))
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(MAX_PAN_RAD * DEFAULT_GAINS["idle"])
+
+
+def test_child_speaking_gain_is_one():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("child_speaking")
+    tracker.publish((1.0, 0.0))
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(MAX_PAN_RAD * 1.0)
+
+
+def test_robot_speaking_gain_reduces_offset():
+    mixer, tracker, _ = _make()
+    tracker.publish((1.0, 0.0))
+    mixer.set_gain_state("robot_speaking")
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(
+        MAX_PAN_RAD * DEFAULT_GAINS["robot_speaking"]
+    )
+
+
+def test_unknown_gain_state_is_logged_and_ignored():
+    mixer, tracker, _ = _make()
+    mixer.set_gain_state("not_a_state")
+    # State unchanged from default ("idle").
+    assert mixer.gain_state == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Robot-speaking hold (don't re-pick mid-utterance)
+# ---------------------------------------------------------------------------
+
+
+def test_robot_speaking_holds_target_when_tracker_publishes_none():
+    mixer, tracker, _ = _make()
+    tracker.publish((0.5, 0.5))
+    mixer.set_gain_state("robot_speaking")
+    # Tracker briefly loses the subject.
+    tracker.publish(None)
+    offset = mixer.current_offset()
+    # Should still be looking at the snapshot — non-zero.
+    assert offset.head_yaw != 0.0
+    assert offset.head_pitch != 0.0
+
+
+def test_robot_speaking_holds_target_when_tracker_re_publishes_different_target():
+    """While the robot is talking we should NOT swing to a new subject."""
+    mixer, tracker, _ = _make()
+    tracker.publish((0.5, 0.0))
+    mixer.set_gain_state("robot_speaking")
+    expected_yaw = mixer.current_offset().head_yaw
+    # A new subject appears — we ignore it during robot speech.
+    tracker.publish((-1.0, 0.0))
+    # Many ticks later the offset is still roughly the same.
+    for _ in range(20):
+        mixer.current_offset()
+    assert mixer.current_offset().head_yaw == pytest.approx(expected_yaw, abs=1e-9)
+
+
+def test_set_robot_speaking_snaps_held_to_latest_target():
+    """Entering robot_speaking should lock onto the freshest known target."""
+    mixer, tracker, _ = _make()
+    tracker.publish((0.2, 0.0))
+    tracker.publish((0.8, 0.0))  # newest target right before the lock
+    mixer.set_gain_state("robot_speaking")
+    tracker.publish(None)
+    offset = mixer.current_offset()
+    # Held value should reflect the 0.8 publish, not the earlier 0.2.
+    assert offset.head_yaw == pytest.approx(
+        MAX_PAN_RAD * 0.8 * DEFAULT_GAINS["robot_speaking"]
+    )
+
+
+def test_idle_state_follows_new_target_after_publish():
+    mixer, tracker, _ = _make()
+    tracker.publish((0.2, 0.0))
+    mixer.current_offset()
+    tracker.publish((-0.2, 0.0))
+    # Long enough for slew to catch up.
+    _, _, clock = (mixer, tracker, None)
+    # We don't have a clock handle here; just call current_offset enough
+    # times relying on the test fixture's clock advances.
+    # Use a fresh helper:
+    clock = _FakeClock()
+    mixer = FaceOffsetMixer(clock=clock)
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    tracker.publish((0.2, 0.0))
+    mixer.current_offset()
+    tracker.publish((-0.2, 0.0))
+    clock.advance(2.0)
+    offset = mixer.current_offset()
+    assert offset.head_yaw < 0
+
+
+# ---------------------------------------------------------------------------
+# Slew rate
+# ---------------------------------------------------------------------------
+
+
+def test_first_tick_snaps_to_target():
+    """No prior displayed offset → snap to target on first tick."""
+    clock = _FakeClock()
+    mixer = FaceOffsetMixer(clock=clock)
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    mixer.set_gain_state("child_speaking")
+    tracker.publish((1.0, 0.0))
+    offset = mixer.current_offset()
+    assert offset.head_yaw == pytest.approx(MAX_PAN_RAD)
+
+
+def test_slew_rate_caps_angular_velocity():
+    """Big jumps are spread over multiple ticks at the velocity cap."""
+    clock = _FakeClock()
+    mixer = FaceOffsetMixer(clock=clock)
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    mixer.set_gain_state("child_speaking")
+
+    # Start at one extreme, settle.
+    tracker.publish((-1.0, 0.0))
+    mixer.current_offset()
+    # Jump to the other extreme.
+    tracker.publish((1.0, 0.0))
+    # One tick at 16ms — should not have crossed the full ±20° in one frame.
+    clock.advance(0.016)
+    intermediate = mixer.current_offset().head_yaw
+    assert intermediate < MAX_PAN_RAD
+    assert intermediate > -MAX_PAN_RAD
+
+    # Eventually catches up.
+    clock.advance(2.0)
+    final = mixer.current_offset().head_yaw
+    assert final == pytest.approx(MAX_PAN_RAD)
+
+
+def test_slew_rate_max_step_per_tick_respects_velocity_cap():
+    """Per-tick step ≤ max_velocity * dt."""
+    clock = _FakeClock()
+    mixer = FaceOffsetMixer(
+        clock=clock, max_angular_velocity_rad_s=math.radians(60.0)
+    )
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    mixer.set_gain_state("child_speaking")
+
+    tracker.publish((-1.0, 0.0))
+    mixer.current_offset()
+    tracker.publish((1.0, 0.0))
+    clock.advance(0.1)  # 100ms at 60°/s = 6° max step
+    step = mixer.current_offset().head_yaw - (-MAX_PAN_RAD)
+    # Ensure we didn't exceed 6° + tiny tolerance.
+    assert step <= math.radians(6.0) + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Recovery toward neutral when tracker drops the subject
+# ---------------------------------------------------------------------------
+
+
+def test_target_lost_eases_back_to_neutral():
+    clock = _FakeClock()
+    mixer = FaceOffsetMixer(clock=clock)
+    tracker = _FakeTracker()
+    mixer.attach(tracker)
+    mixer.set_gain_state("idle")
+    tracker.publish((1.0, 0.0))
+    mixer.current_offset()
+    tracker.publish(None)
+    # Plenty of time to slew back.
+    clock.advance(2.0)
+    assert mixer.current_offset() == NEUTRAL

--- a/tests/test_motion_library.py
+++ b/tests/test_motion_library.py
@@ -1,0 +1,161 @@
+"""Unit tests for :mod:`motion.library`."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from motion.library import (
+    Clip,
+    ChoreographyLibrary,
+    default_library,
+)
+from motion.types import NEUTRAL, PoseOffset
+
+
+def _const_clip(name: str, duration: float, lane: str, value: PoseOffset) -> Clip:
+    return Clip(name=name, duration=duration, lane=lane, pose_at=lambda t: value)  # noqa: ARG005
+
+
+def test_register_then_get_returns_clip():
+    lib = ChoreographyLibrary()
+    clip = _const_clip("foo", 1.0, "affect", PoseOffset(head_pitch=0.1))
+    lib.register(clip)
+    assert lib.get("foo") is clip
+
+
+def test_get_unknown_returns_none():
+    lib = ChoreographyLibrary()
+    assert lib.get("does_not_exist") is None
+
+
+def test_register_duplicate_name_raises():
+    lib = ChoreographyLibrary()
+    lib.register(_const_clip("foo", 1.0, "affect", NEUTRAL))
+    with pytest.raises(ValueError):
+        lib.register(_const_clip("foo", 2.0, "affect", NEUTRAL))
+
+
+def test_names_returns_sorted_list():
+    lib = ChoreographyLibrary(
+        [
+            _const_clip("zebra", 1.0, "affect", NEUTRAL),
+            _const_clip("apple", 1.0, "affect", NEUTRAL),
+            _const_clip("mango", 1.0, "affect", NEUTRAL),
+        ]
+    )
+    assert lib.names() == ["apple", "mango", "zebra"]
+
+
+def test_contains_only_matches_strings():
+    lib = ChoreographyLibrary([_const_clip("foo", 1.0, "affect", NEUTRAL)])
+    assert "foo" in lib
+    assert "bar" not in lib
+    assert 5 not in lib  # type: ignore[operator]
+
+
+# ---------------------------------------------------------------------------
+# default_library V1 vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_default_library_has_expected_v1_clips():
+    lib = default_library()
+    expected = {
+        "cancel",
+        "head_tilt_curious",
+        "mini_dance_excited",
+        "nod_encourage",
+        "sad_droop",
+        "surprise_pop",
+        "thinking_up",
+        "victory_wiggle",
+    }
+    assert set(lib.names()) == expected
+
+
+def test_default_clips_return_neutral_outside_duration():
+    lib = default_library()
+    for name in lib.names():
+        clip = lib.get(name)
+        assert clip is not None
+        assert clip.pose_at(-0.5) == NEUTRAL
+        assert clip.pose_at(clip.duration) == NEUTRAL
+        assert clip.pose_at(clip.duration + 1.0) == NEUTRAL
+
+
+def test_default_clips_return_neutral_at_boundaries_due_to_envelope():
+    """All envelope-shaped clips ramp from / to zero. Cancel + tilt clips
+    are exempt because tilt holds and cancel is constant-zero."""
+    lib = default_library()
+    for name in ("nod_encourage", "mini_dance_excited", "victory_wiggle", "sad_droop"):
+        clip = lib.get(name)
+        assert clip is not None
+        # Just inside both ends, the envelope is ~0 so the offset is ~0.
+        epsilon = 1e-6
+        assert _close_to_neutral(clip.pose_at(epsilon))
+        assert _close_to_neutral(clip.pose_at(clip.duration - epsilon))
+
+
+def test_cancel_clip_is_always_neutral():
+    clip = default_library().get("cancel")
+    assert clip is not None
+    for t in (0.0, 0.1, 0.2, 0.3):
+        assert clip.pose_at(t) == NEUTRAL
+
+
+def test_nod_encourage_actually_nods():
+    """At the peak of the first nod we should be well away from neutral."""
+    clip = default_library().get("nod_encourage")
+    assert clip is not None
+    # 2-cycle sinusoid: zeros at u=0, 0.25, 0.5, 0.75, 1.0 — sample at the
+    # peak between zeros (u=0.125) where sin(2π·2·u) = sin(π/2) = 1.
+    pose = clip.pose_at(clip.duration * 0.125)
+    assert abs(pose.head_pitch) > 0.01
+    # The rest of the channels should be unaffected.
+    assert pose.head_roll == 0.0
+    assert pose.antenna_left == 0.0
+
+
+def test_head_tilt_curious_holds_target_in_middle():
+    clip = default_library().get("head_tilt_curious")
+    assert clip is not None
+    pose = clip.pose_at(clip.duration * 0.5)
+    # At midpoint the trapezoid envelope is fully on, so roll = target.
+    assert math.isclose(pose.head_roll, math.radians(15.0), rel_tol=1e-6)
+
+
+def test_mini_dance_excited_drives_antennae_in_opposition():
+    clip = default_library().get("mini_dance_excited")
+    assert clip is not None
+    # Sample several points; antenna L and R should always sum to ~zero.
+    for u in (0.2, 0.35, 0.5, 0.7, 0.85):
+        pose = clip.pose_at(clip.duration * u)
+        assert math.isclose(
+            pose.antenna_left + pose.antenna_right, 0.0, abs_tol=1e-9
+        )
+
+
+def test_clip_metadata_lanes():
+    lib = default_library()
+    assert lib.get("cancel").lane == "system"  # type: ignore[union-attr]
+    assert lib.get("mini_dance_excited").lane == "celebration"  # type: ignore[union-attr]
+    assert lib.get("victory_wiggle").lane == "celebration"  # type: ignore[union-attr]
+    assert lib.get("nod_encourage").lane == "affect"  # type: ignore[union-attr]
+
+
+def _close_to_neutral(pose: PoseOffset, abs_tol: float = 1e-3) -> bool:
+    return all(
+        abs(getattr(pose, field)) <= abs_tol
+        for field in (
+            "head_pitch",
+            "head_yaw",
+            "head_roll",
+            "head_x",
+            "head_y",
+            "head_z",
+            "antenna_left",
+            "antenna_right",
+        )
+    )

--- a/tests/test_motion_scheduler.py
+++ b/tests/test_motion_scheduler.py
@@ -1,0 +1,338 @@
+"""Unit tests for :mod:`motion.scheduler`."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from motion.composer import MovementComposer
+from motion.library import ChoreographyLibrary, Clip
+from motion.scheduler import (
+    DEFAULT_GLOBAL_COOLDOWN_S,
+    DEFAULT_PER_NAME_COOLDOWN_S,
+    GestureDecision,
+    GestureScheduler,
+)
+from motion.types import NEUTRAL, PoseOffset
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+def _make_clip(name: str, lane: str, duration: float = 1.0) -> Clip:
+    return Clip(name=name, duration=duration, lane=lane, pose_at=lambda t: NEUTRAL)  # noqa: ARG005
+
+
+def _make_library() -> ChoreographyLibrary:
+    return ChoreographyLibrary(
+        [
+            _make_clip("nod_encourage", "affect", 1.0),
+            _make_clip("head_tilt_curious", "affect", 1.0),
+            _make_clip("mini_dance_excited", "celebration", 2.0),
+            _make_clip("victory_wiggle", "celebration", 2.0),
+            _make_clip("cancel", "system", 0.4),
+        ]
+    )
+
+
+def _make() -> Tuple[GestureScheduler, MovementComposer, _FakeClock, List[GestureDecision]]:
+    clock = _FakeClock()
+    sink_calls: List[Tuple[PoseOffset, float]] = []
+
+    def _sink(offset: PoseOffset, period: float) -> None:
+        sink_calls.append((offset, period))
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+    decisions: List[GestureDecision] = []
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=_make_library(),
+        clock=clock,
+        decision_logger=decisions.append,
+    )
+    return scheduler, composer, clock, decisions
+
+
+# ---------------------------------------------------------------------------
+# Acceptance / rejection
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_gesture_is_rejected_and_does_not_play():
+    scheduler, composer, clock, decisions = _make()
+    decision = scheduler.request("does_not_exist")
+    assert decision.accepted is False
+    assert decision.reason == "unknown_gesture"
+    assert composer.compose_pose(clock.now) == NEUTRAL
+    assert decisions[-1] == decision
+
+
+def test_first_gesture_is_accepted_and_starts_clip():
+    scheduler, composer, clock, decisions = _make()
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is True
+    assert decision.lane == "affect"
+    # Composer is now driving the clip.
+    pose = composer.compose_pose(clock.now)
+    # The fake clip is constant-NEUTRAL so the offset is also neutral, but
+    # the composer's active clip is set — request a different clip and
+    # verify it preempts.
+    assert decisions[-1].accepted is True
+
+
+# ---------------------------------------------------------------------------
+# Per-name cooldown
+# ---------------------------------------------------------------------------
+
+
+def test_same_gesture_within_per_name_cooldown_is_dropped():
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    # Far past clip duration but inside the per-name window.
+    clock.advance(DEFAULT_PER_NAME_COOLDOWN_S - 0.1)
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is False
+    assert decision.reason == "per_name_cooldown"
+
+
+def test_same_gesture_after_per_name_cooldown_is_accepted():
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    clock.advance(DEFAULT_PER_NAME_COOLDOWN_S + 0.1)
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is True
+
+
+def test_per_name_cooldown_is_per_name():
+    """Different names share only the global cooldown, not per-name."""
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    # Past global cooldown but inside per-name (different name so per-name
+    # doesn't apply, only global must clear).
+    clock.advance(DEFAULT_GLOBAL_COOLDOWN_S + 0.1)
+    decision = scheduler.request("head_tilt_curious")
+    assert decision.accepted is True
+
+
+# ---------------------------------------------------------------------------
+# Global rate cap
+# ---------------------------------------------------------------------------
+
+
+def test_two_different_gestures_inside_global_cooldown_are_dropped():
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    clock.advance(DEFAULT_GLOBAL_COOLDOWN_S - 0.1)
+    decision = scheduler.request("head_tilt_curious")
+    assert decision.accepted is False
+    assert decision.reason == "global_cooldown"
+
+
+def test_global_cooldown_clears_after_window():
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    clock.advance(DEFAULT_GLOBAL_COOLDOWN_S + 0.1)
+    decision = scheduler.request("head_tilt_curious")
+    assert decision.accepted is True
+
+
+def test_system_lane_gesture_bypasses_global_cooldown():
+    """``cancel`` must always succeed even mid-rate-cap."""
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    # Inside global cooldown.
+    clock.advance(0.1)
+    decision = scheduler.request("cancel")
+    assert decision.accepted is True
+
+
+# ---------------------------------------------------------------------------
+# Lane priority preemption
+# ---------------------------------------------------------------------------
+
+
+def test_higher_lane_preempts_lower_lane_clip():
+    scheduler, composer, clock, _ = _make()
+    # Affect-lane clip is playing.
+    assert scheduler.request("nod_encourage").accepted
+    # Inside global cooldown — celebration should still preempt because
+    # the priority comparison happens before the global-cooldown check?
+    # No — global cooldown applies. Wait past it, then preempt.
+    clock.advance(DEFAULT_GLOBAL_COOLDOWN_S + 0.1)
+    decision = scheduler.request("mini_dance_excited")
+    assert decision.accepted is True
+    # The composer's active clip should now be the dance (affect was
+    # preempted because celebration > affect).
+
+
+def test_lower_lane_drops_when_higher_clip_is_playing():
+    scheduler, _, clock, _ = _make()
+    # Celebration takes the lane.
+    assert scheduler.request("mini_dance_excited").accepted
+    # Past global cooldown but still mid-clip (clip duration = 2.0s).
+    clock.advance(DEFAULT_GLOBAL_COOLDOWN_S + 0.1)  # = 4.1s, but clip is 2s
+    # Need a still-active clip — use a longer one. Re-request before
+    # duration expires.
+    # Actually 4.1s > 2.0s clip duration, so the clip has expired and any
+    # request should be accepted. Let's use a tighter timeline.
+
+    scheduler2, _, clock2, _ = _make()
+    assert scheduler2.request("mini_dance_excited").accepted
+    # Past global cooldown but inside clip duration: clip = 2s, cooldown = 4s.
+    # We need the celebration clip to still be active when we request affect.
+    # That requires waiting < 2s but global cooldown forces >= 4s wait.
+    # So test the inverse: use system "cancel" which bypasses global cooldown.
+    clock2.advance(0.5)  # Mid-celebration
+    decision = scheduler2.request("nod_encourage")  # affect — drops on global cooldown first
+    assert decision.accepted is False
+    assert decision.reason == "global_cooldown"
+
+
+def test_lower_priority_drop_after_global_cooldown_is_lane_decision():
+    """Build a scenario where global cooldown is short enough that lane
+    priority is the dropping reason, not global cooldown."""
+    library = _make_library()
+    clock = _FakeClock()
+
+    def _sink(_offset, _period):
+        return None
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=library,
+        clock=clock,
+        per_name_cooldown_s=8.0,
+        global_cooldown_s=0.05,  # tiny so lane priority dominates
+    )
+    assert scheduler.request("mini_dance_excited").accepted  # celebration, 2s
+    clock.advance(0.5)  # mid-dance, past tiny global cooldown
+    decision = scheduler.request("nod_encourage")  # affect
+    assert decision.accepted is False
+    assert decision.reason == "lower_priority"
+
+
+def test_equal_lane_request_is_dropped_during_active_clip():
+    library = _make_library()
+    clock = _FakeClock()
+
+    def _sink(_offset, _period):
+        return None
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=library,
+        clock=clock,
+        global_cooldown_s=0.05,
+    )
+    # Affect clip in flight.
+    assert scheduler.request("nod_encourage").accepted
+    clock.advance(0.2)
+    # Different affect-lane gesture — equal priority drops.
+    decision = scheduler.request("head_tilt_curious")
+    assert decision.accepted is False
+    assert decision.reason == "lower_priority"
+
+
+def test_after_active_clip_expires_lower_lane_can_play_again():
+    library = _make_library()
+    clock = _FakeClock()
+
+    def _sink(_offset, _period):
+        return None
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=library,
+        clock=clock,
+        global_cooldown_s=0.05,
+        per_name_cooldown_s=0.05,
+    )
+    assert scheduler.request("mini_dance_excited").accepted  # 2s celebration
+    clock.advance(2.5)  # past celebration, past all cooldowns
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is True
+
+
+# ---------------------------------------------------------------------------
+# flush / barge-in
+# ---------------------------------------------------------------------------
+
+
+def test_flush_cancels_active_clip_in_composer():
+    scheduler, composer, clock, _ = _make()
+    assert scheduler.request("mini_dance_excited").accepted
+    scheduler.flush()
+    # Composer's active clip should now be None — verify by setting state
+    # to idle and asserting compose_pose is NEUTRAL.
+    composer.set_state("idle")
+    assert composer.compose_pose(clock.now) == NEUTRAL
+
+
+def test_flush_preserves_per_name_cooldown():
+    """Barge-in should not let the LLM immediately re-fire the same gesture."""
+    scheduler, _, clock, _ = _make()
+    assert scheduler.request("nod_encourage").accepted
+    scheduler.flush()
+    clock.advance(0.1)  # well inside per-name cooldown
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is False
+    assert decision.reason == "per_name_cooldown"
+
+
+# ---------------------------------------------------------------------------
+# Decision logger
+# ---------------------------------------------------------------------------
+
+
+def test_decision_logger_receives_every_decision():
+    scheduler, _, clock, decisions = _make()
+    scheduler.request("does_not_exist")
+    scheduler.request("nod_encourage")
+    clock.advance(0.1)
+    scheduler.request("nod_encourage")  # cooldown drop
+    assert [d.accepted for d in decisions] == [False, True, False]
+    assert [d.reason for d in decisions] == [
+        "unknown_gesture",
+        None,
+        "per_name_cooldown",
+    ]
+
+
+def test_decision_logger_exception_does_not_break_request():
+    library = _make_library()
+    clock = _FakeClock()
+
+    def _sink(_offset, _period):
+        return None
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+
+    def _broken(_decision: GestureDecision) -> None:
+        raise RuntimeError("logger boom")
+
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=library,
+        clock=clock,
+        decision_logger=_broken,
+    )
+    # Must not raise even though the logger does.
+    decision = scheduler.request("nod_encourage")
+    assert decision.accepted is True

--- a/tests/test_motion_stack.py
+++ b/tests/test_motion_stack.py
@@ -1,0 +1,236 @@
+"""Unit tests for :mod:`motion.stack`."""
+
+from __future__ import annotations
+
+import struct
+from typing import List
+
+import pytest
+
+from motion.stack import (
+    ALL_LAYERS,
+    LAYER_GESTURES,
+    LAYER_TRACKING,
+    LAYER_WOBBLE,
+    MotionStack,
+    MotionStackConfig,
+    parse_layers,
+)
+from motion.tool_specs import (
+    PLAY_GESTURE_TOOL_NAME,
+    STOP_MOTION_TOOL_NAME,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeRobotController:
+    def __init__(self) -> None:
+        self.pose_calls: List[dict] = []
+
+    def apply_pose(self, **kwargs) -> bool:
+        self.pose_calls.append(kwargs)
+        return True
+
+
+class _FakeTracker:
+    def __init__(self) -> None:
+        self.subscribers: List = []
+
+    def subscribe(self, cb):
+        self.subscribers.append(cb)
+        return lambda: self.subscribers.remove(cb)
+
+    def publish(self, target):
+        for cb in list(self.subscribers):
+            cb(target)
+
+
+def _loud_chunk(n: int = 480) -> bytes:
+    import math
+
+    return struct.pack(
+        f"<{n}h", *(int(12000 * math.sin(2 * math.pi * 440 * i / 24000)) for i in range(n))
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_layers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spec", [None, "", "full", "FULL"])
+def test_parse_layers_defaults_to_all(spec):
+    assert parse_layers(spec) == ALL_LAYERS
+
+
+def test_parse_layers_none_yields_empty():
+    assert parse_layers("none") == frozenset()
+
+
+def test_parse_layers_csv_subset():
+    assert parse_layers("wobble,tracking") == frozenset({"wobble", "tracking"})
+
+
+def test_parse_layers_drops_unknown_layers():
+    assert parse_layers("wobble,quasar") == frozenset({"wobble"})
+
+
+def test_parse_layers_handles_extra_whitespace():
+    assert parse_layers(" gestures , tracking ") == frozenset({"gestures", "tracking"})
+
+
+# ---------------------------------------------------------------------------
+# Construction with subsets of layers
+# ---------------------------------------------------------------------------
+
+
+def test_full_stack_constructs_all_layers():
+    robot = _FakeRobotController()
+    stack = MotionStack(robot_controller=robot)
+    # additional_tool_specs is the visible signal that the gestures layer
+    # is on.
+    names = {t["name"] for t in stack.additional_tool_specs()}
+    assert names == {PLAY_GESTURE_TOOL_NAME, STOP_MOTION_TOOL_NAME}
+
+
+def test_no_layers_means_no_tools_or_face_subscription():
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset()),
+    )
+    assert stack.additional_tool_specs() == []
+    assert stack.gesture_vocabulary_prompt_block() == ""
+
+    tracker = _FakeTracker()
+    stack.attach_face_tracker(tracker)  # should be no-op
+    assert tracker.subscribers == []
+
+
+def test_only_tracking_layer_subscribes_to_tracker_but_skips_tools():
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset({LAYER_TRACKING})),
+    )
+    assert stack.additional_tool_specs() == []
+    tracker = _FakeTracker()
+    stack.attach_face_tracker(tracker)
+    assert len(tracker.subscribers) == 1
+
+
+def test_only_wobble_layer_feeds_wobbler_only():
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset({LAYER_WOBBLE})),
+    )
+    # Should be safe to call; tracker calls become no-ops.
+    stack.feed_assistant_audio(_loud_chunk())
+    assert stack.additional_tool_specs() == []
+
+
+# ---------------------------------------------------------------------------
+# Bridge-facing hooks
+# ---------------------------------------------------------------------------
+
+
+def test_feed_assistant_audio_no_op_when_wobble_disabled():
+    """Should not raise even though there's no wobbler."""
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset({LAYER_GESTURES})),
+    )
+    stack.feed_assistant_audio(_loud_chunk())  # no exception
+
+
+def test_handle_tool_call_routes_to_router():
+    robot = _FakeRobotController()
+    stack = MotionStack(robot_controller=robot)
+    payload = stack.handle_tool_call(
+        "call_1", PLAY_GESTURE_TOOL_NAME, '{"name": "nod_encourage"}'
+    )
+    assert payload is not None
+    import json
+    assert json.loads(payload)["ok"] is True
+
+
+def test_handle_tool_call_returns_none_when_gestures_disabled():
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset({LAYER_WOBBLE, LAYER_TRACKING})),
+    )
+    assert stack.handle_tool_call("c", PLAY_GESTURE_TOOL_NAME, "{}") is None
+
+
+def test_enter_exit_assistant_speech_does_not_raise_with_no_layers():
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset()),
+    )
+    # Smoke: every bridge hook callable with no layers.
+    stack.enter_assistant_speech()
+    stack.exit_assistant_speech()
+    stack.enter_child_speech()
+    stack.exit_child_speech()
+    stack.set_idle()
+
+
+def test_face_tracker_target_drives_pose_sink():
+    """End-to-end smoke: tracker publish → composer tick → robot.apply_pose."""
+    robot = _FakeRobotController()
+    stack = MotionStack(robot_controller=robot)
+    tracker = _FakeTracker()
+    stack.attach_face_tracker(tracker)
+
+    # Push a target and tick the composer manually.
+    tracker.publish((0.5, 0.0))
+    stack._composer.tick_at(0.0)
+    stack._composer.tick_at(1.0)  # let slew settle
+
+    assert robot.pose_calls
+    last = robot.pose_calls[-1]
+    # head_yaw should be > 0 (positive pan -> turn right).
+    assert last["head_yaw"] > 0
+
+
+def test_pose_sink_with_robot_lacking_apply_pose_is_silent():
+    class _BareRobot:
+        pass
+
+    stack = MotionStack(robot_controller=_BareRobot())
+    # Tick should not raise even though apply_pose is missing.
+    stack._composer.tick_at(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_start_then_stop_runs_at_least_one_tick():
+    import time as _time
+
+    robot = _FakeRobotController()
+    stack = MotionStack(
+        robot_controller=robot,
+        config=MotionStackConfig(layers=frozenset(), tick_hz=200.0),
+    )
+    stack.start()
+    deadline = _time.monotonic() + 1.0
+    while _time.monotonic() < deadline and len(robot.pose_calls) < 3:
+        _time.sleep(0.005)
+    stack.stop(timeout=1.0)
+    assert len(robot.pose_calls) >= 3
+
+
+def test_stop_without_start_is_safe():
+    stack = MotionStack(robot_controller=_FakeRobotController())
+    stack.stop()

--- a/tests/test_motion_tool_specs.py
+++ b/tests/test_motion_tool_specs.py
@@ -1,0 +1,232 @@
+"""Unit tests for :mod:`motion.tool_specs`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from motion.composer import MovementComposer
+from motion.library import ChoreographyLibrary, Clip, default_library
+from motion.scheduler import GestureScheduler
+from motion.tool_specs import (
+    MOTION_TOOL_NAMES,
+    PLAY_GESTURE_TOOL_NAME,
+    STOP_MOTION_TOOL_NAME,
+    GestureToolRouter,
+    ToolCallResult,
+    gesture_tool_specs,
+    gesture_vocabulary_prompt_block,
+)
+from motion.types import NEUTRAL, PoseOffset
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+def _make_router(library: ChoreographyLibrary | None = None):
+    library = library or default_library()
+    clock = _FakeClock()
+
+    def _sink(_offset: PoseOffset, _period: float) -> None:
+        return None
+
+    composer = MovementComposer(pose_sink=_sink, tick_hz=30.0, clock=clock)
+    scheduler = GestureScheduler(
+        composer=composer,
+        library=library,
+        clock=clock,
+    )
+    return GestureToolRouter(scheduler=scheduler), scheduler, clock
+
+
+# ---------------------------------------------------------------------------
+# tool specs
+# ---------------------------------------------------------------------------
+
+
+def test_gesture_tool_specs_has_play_and_stop():
+    specs = gesture_tool_specs(default_library())
+    names = {s["name"] for s in specs}
+    assert names == {PLAY_GESTURE_TOOL_NAME, STOP_MOTION_TOOL_NAME}
+
+
+def test_play_gesture_enum_lists_every_clip():
+    library = default_library()
+    specs = gesture_tool_specs(library)
+    play = next(s for s in specs if s["name"] == PLAY_GESTURE_TOOL_NAME)
+    assert sorted(play["parameters"]["properties"]["name"]["enum"]) == library.names()
+
+
+def test_play_gesture_requires_name():
+    specs = gesture_tool_specs(default_library())
+    play = next(s for s in specs if s["name"] == PLAY_GESTURE_TOOL_NAME)
+    assert play["parameters"]["required"] == ["name"]
+    assert play["parameters"]["additionalProperties"] is False
+
+
+def test_stop_motion_takes_no_args():
+    specs = gesture_tool_specs(default_library())
+    stop = next(s for s in specs if s["name"] == STOP_MOTION_TOOL_NAME)
+    assert stop["parameters"]["required"] == []
+    assert stop["parameters"]["properties"] == {}
+
+
+def test_motion_tool_names_constant_matches_specs():
+    assert set(MOTION_TOOL_NAMES) == {
+        s["name"] for s in gesture_tool_specs(default_library())
+    }
+
+
+def test_specs_are_json_serializable():
+    """The OpenAI Realtime SDK serialises to JSON — fail loudly if we can't."""
+    specs = gesture_tool_specs(default_library())
+    json.dumps(specs)
+
+
+def test_vocabulary_prompt_block_mentions_gestures():
+    block = gesture_vocabulary_prompt_block()
+    assert "play_gesture" in block
+    for name in (
+        "nod_encourage",
+        "head_tilt_curious",
+        "mini_dance_excited",
+        "victory_wiggle",
+    ):
+        assert name in block
+
+
+# ---------------------------------------------------------------------------
+# ToolCallResult
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_result_to_payload_round_trips():
+    result = ToolCallResult(ok=True, detail="playing nod_encourage")
+    parsed = json.loads(result.to_payload())
+    assert parsed == {"ok": True, "detail": "playing nod_encourage"}
+
+
+# ---------------------------------------------------------------------------
+# GestureToolRouter — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_play_gesture_with_dict_args_routes_to_scheduler():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, {"name": "nod_encourage"})
+    assert result.ok is True
+    assert "nod_encourage" in result.detail
+
+
+def test_play_gesture_with_json_string_args_routes_to_scheduler():
+    """OpenAI Realtime ships function args as JSON strings."""
+    router, _, _ = _make_router()
+    result = router.dispatch(
+        PLAY_GESTURE_TOOL_NAME, json.dumps({"name": "head_tilt_curious"})
+    )
+    assert result.ok is True
+
+
+def test_stop_motion_flushes_scheduler():
+    router, scheduler, _ = _make_router()
+    # Start a gesture so we have something to flush.
+    scheduler.request("nod_encourage")
+    result = router.dispatch(STOP_MOTION_TOOL_NAME, {})
+    assert result.ok is True
+    assert "stopped" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# GestureToolRouter — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tool_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch("send_email", {"to": "x"})
+    assert result.ok is False
+    assert "unknown tool" in result.detail
+
+
+def test_play_gesture_with_unknown_clip_reports_drop_reason():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, {"name": "tango"})
+    assert result.ok is False
+    assert "unknown_gesture" in result.detail
+
+
+def test_play_gesture_with_missing_name_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, {})
+    assert result.ok is False
+    assert "name" in result.detail
+
+
+def test_play_gesture_with_non_string_name_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, {"name": 7})
+    assert result.ok is False
+
+
+def test_play_gesture_with_invalid_json_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, "{not json")
+    assert result.ok is False
+    assert "invalid arguments" in result.detail
+
+
+def test_play_gesture_with_empty_string_args_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, "")
+    assert result.ok is False  # empty -> {} -> missing name
+
+
+def test_play_gesture_with_bytes_json_args_works():
+    router, _, _ = _make_router()
+    result = router.dispatch(
+        PLAY_GESTURE_TOOL_NAME, b'{"name": "sad_droop"}'
+    )
+    assert result.ok is True
+
+
+def test_play_gesture_with_non_object_json_returns_error():
+    router, _, _ = _make_router()
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, "[1, 2, 3]")
+    assert result.ok is False
+
+
+def test_dispatch_never_raises_on_garbage():
+    """Tool-router safety: any input must produce a result, never raise."""
+    router, _, _ = _make_router()
+    for arg in (None, 42, 3.14, object()):
+        result = router.dispatch(PLAY_GESTURE_TOOL_NAME, arg)
+        assert isinstance(result, ToolCallResult)
+        assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Cooldown propagation
+# ---------------------------------------------------------------------------
+
+
+def test_play_gesture_inside_cooldown_reports_drop_reason():
+    router, _, clock = _make_router()
+    router.dispatch(PLAY_GESTURE_TOOL_NAME, {"name": "nod_encourage"})
+    clock.advance(0.5)  # well inside per-name cooldown
+    result = router.dispatch(PLAY_GESTURE_TOOL_NAME, {"name": "nod_encourage"})
+    assert result.ok is False
+    assert "per_name_cooldown" in result.detail

--- a/tests/test_motion_types.py
+++ b/tests/test_motion_types.py
@@ -1,0 +1,77 @@
+"""Unit tests for :mod:`motion.types`."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from motion.types import NEUTRAL, PoseOffset
+
+
+def test_neutral_is_all_zero():
+    assert NEUTRAL == PoseOffset()
+    assert NEUTRAL.head_pitch == 0.0
+    assert NEUTRAL.antenna_left == 0.0
+
+
+def test_addition_sums_every_channel():
+    a = PoseOffset(head_pitch=0.1, antenna_left=0.2)
+    b = PoseOffset(head_pitch=0.3, head_yaw=-0.4, antenna_right=0.5)
+    c = a + b
+    assert c == PoseOffset(
+        head_pitch=0.4,
+        head_yaw=-0.4,
+        antenna_left=0.2,
+        antenna_right=0.5,
+    )
+
+
+def test_addition_with_non_pose_returns_notimplemented():
+    a = PoseOffset(head_pitch=0.1)
+    with pytest.raises(TypeError):
+        _ = a + 5  # type: ignore[operator]
+
+
+def test_scaled_multiplies_every_channel():
+    a = PoseOffset(head_pitch=0.2, antenna_left=0.5)
+    scaled = a.scaled(0.5)
+    assert scaled == PoseOffset(head_pitch=0.1, antenna_left=0.25)
+
+
+def test_scaled_by_zero_yields_neutral():
+    a = PoseOffset(head_pitch=1.0, antenna_left=1.0, head_z=0.5)
+    assert a.scaled(0.0) == NEUTRAL
+
+
+def test_clipped_caps_each_channel_independently():
+    cap = PoseOffset(head_pitch=0.1, head_yaw=0.2, antenna_left=0.3)
+    raw = PoseOffset(head_pitch=0.5, head_yaw=-0.5, antenna_left=-0.4)
+    clipped = raw.clipped(cap)
+    assert math.isclose(clipped.head_pitch, 0.1)
+    assert math.isclose(clipped.head_yaw, -0.2)
+    assert math.isclose(clipped.antenna_left, -0.3)
+
+
+def test_clipped_zero_cap_zeroes_channel():
+    cap = PoseOffset()  # all zero
+    raw = PoseOffset(head_pitch=0.5, antenna_left=0.5)
+    assert raw.clipped(cap) == NEUTRAL
+
+
+def test_clipped_within_bounds_is_unchanged():
+    cap = PoseOffset(head_pitch=1.0, antenna_left=1.0)
+    raw = PoseOffset(head_pitch=0.3, antenna_left=-0.7)
+    assert raw.clipped(cap) == raw
+
+
+def test_clipped_uses_absolute_cap_value():
+    cap = PoseOffset(head_pitch=-0.1)  # negative caps treated as magnitude
+    raw = PoseOffset(head_pitch=0.5)
+    assert math.isclose(raw.clipped(cap).head_pitch, 0.1)
+
+
+def test_with_replaces_only_named_channels():
+    a = PoseOffset(head_pitch=0.1, antenna_left=0.2, antenna_right=0.3)
+    b = a.with_(head_pitch=0.0)
+    assert b == PoseOffset(antenna_left=0.2, antenna_right=0.3)

--- a/tests/test_motion_wobbler.py
+++ b/tests/test_motion_wobbler.py
@@ -1,0 +1,248 @@
+"""Unit tests for :mod:`motion.wobbler`."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+import pytest
+
+from motion.types import NEUTRAL
+from motion.wobbler import AudioWobbler
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+def _pcm16(samples) -> bytes:
+    """Pack a list of ints as little-endian PCM16."""
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def _silent_chunk(n: int = 480) -> bytes:
+    return _pcm16([0] * n)
+
+
+def _loud_chunk(n: int = 480, amplitude: int = 12000) -> bytes:
+    """A loud-ish PCM16 sine chunk at ~440 Hz against 24 kHz."""
+    return _pcm16([int(amplitude * math.sin(2 * math.pi * 440 * i / 24000)) for i in range(n)])
+
+
+# ---------------------------------------------------------------------------
+# Construction & defaults
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_bad_sample_rate():
+    with pytest.raises(ValueError):
+        AudioWobbler(sample_rate=0)
+    with pytest.raises(ValueError):
+        AudioWobbler(sample_rate=-1)
+
+
+def test_initial_offset_is_neutral():
+    w = AudioWobbler(clock=_FakeClock())
+    assert w.current_offset() == NEUTRAL
+
+
+def test_silent_chunk_keeps_offset_neutral():
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    w.feed(_silent_chunk())
+    clock.advance(0.05)
+    assert w.current_offset() == NEUTRAL
+
+
+def test_empty_feed_is_a_noop():
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    w.feed(b"")
+    assert w.current_offset() == NEUTRAL
+
+
+def test_odd_byte_chunk_does_not_crash():
+    """If the backend ever sends a half sample we must not raise."""
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    # Single byte — under one PCM16 sample.
+    w.feed(b"\x01")
+    assert w.current_offset() == NEUTRAL
+    # Odd-byte loud-ish — drop the trailing byte and keep going.
+    w.feed(_loud_chunk() + b"\x7f")
+    clock.advance(0.05)
+    offset = w.current_offset()
+    assert offset != NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Envelope behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_loud_audio_drives_offset_away_from_neutral():
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    # Several loud chunks to drive the envelope up.
+    for _ in range(10):
+        w.feed(_loud_chunk())
+        clock.advance(0.05)
+    offset = w.current_offset()
+    # At least one channel should be away from zero.
+    assert any(
+        abs(getattr(offset, ch)) > 1e-4
+        for ch in (
+            "head_pitch",
+            "head_yaw",
+            "head_roll",
+            "head_z",
+            "antenna_left",
+            "antenna_right",
+        )
+    )
+
+
+def test_envelope_decays_during_silence():
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    for _ in range(10):
+        w.feed(_loud_chunk())
+        clock.advance(0.05)
+    # No more feeds — envelope should decay to ~0 within ~2s.
+    clock.advance(3.0)
+    assert w.current_offset() == NEUTRAL
+
+
+def test_reset_zeroes_envelope_immediately():
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    for _ in range(10):
+        w.feed(_loud_chunk())
+        clock.advance(0.05)
+    # Envelope is up.
+    w.reset()
+    assert w.current_offset() == NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Channel coverage
+# ---------------------------------------------------------------------------
+
+
+def test_default_oscillators_drive_at_least_six_channels():
+    """Smoke: prove every default-driven channel sees motion at some sample."""
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    for _ in range(20):
+        w.feed(_loud_chunk())
+        clock.advance(0.05)
+    seen = {
+        ch: False
+        for ch in (
+            "head_pitch",
+            "head_yaw",
+            "head_roll",
+            "head_z",
+            "antenna_left",
+            "antenna_right",
+        )
+    }
+    # Sample at many points so we don't miss a zero crossing.
+    for _ in range(40):
+        offset = w.current_offset()
+        for ch in seen:
+            if abs(getattr(offset, ch)) > 1e-6:
+                seen[ch] = True
+        clock.advance(0.02)
+        # Keep envelope up for the duration of the probe.
+        w.feed(_loud_chunk())
+    assert all(seen.values()), f"some channels never moved: {seen}"
+
+
+def test_unmoved_channels_stay_zero():
+    """``head_x`` / ``head_y`` are not driven by the default oscillators."""
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    for _ in range(20):
+        w.feed(_loud_chunk())
+        clock.advance(0.05)
+    for _ in range(40):
+        offset = w.current_offset()
+        assert offset.head_x == 0.0
+        assert offset.head_y == 0.0
+        clock.advance(0.02)
+
+
+# ---------------------------------------------------------------------------
+# Amplitude bounds
+# ---------------------------------------------------------------------------
+
+
+def test_offsets_stay_within_oscillator_amplitudes():
+    """Envelope is capped at 1.0, so per-channel output ≤ peak_amplitude."""
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    # Hammer with extremely loud audio.
+    huge = _pcm16([30000] * 480)
+    for _ in range(10):
+        w.feed(huge)
+        clock.advance(0.05)
+    # Sample widely.
+    max_per_channel = {
+        "head_pitch": 0.0,
+        "head_yaw": 0.0,
+        "head_roll": 0.0,
+        "head_z": 0.0,
+        "antenna_left": 0.0,
+        "antenna_right": 0.0,
+    }
+    for _ in range(200):
+        offset = w.current_offset()
+        for ch in max_per_channel:
+            max_per_channel[ch] = max(max_per_channel[ch], abs(getattr(offset, ch)))
+        clock.advance(0.005)
+        w.feed(huge)
+
+    # Bounds drawn from the default oscillator amplitudes (with a tiny
+    # slack for floating-point + interaction with the envelope ceiling).
+    assert max_per_channel["head_pitch"] <= math.radians(3.0) * 1.05
+    assert max_per_channel["head_yaw"] <= math.radians(2.0) * 1.05
+    assert max_per_channel["head_roll"] <= math.radians(1.0) * 1.05
+    assert max_per_channel["head_z"] <= 0.0025 * 1.05
+    assert max_per_channel["antenna_left"] <= math.radians(8.0) * 1.05
+    assert max_per_channel["antenna_right"] <= math.radians(8.0) * 1.05
+
+
+# ---------------------------------------------------------------------------
+# Concurrency smoke
+# ---------------------------------------------------------------------------
+
+
+def test_feed_and_current_offset_concurrent():
+    import threading
+
+    clock = _FakeClock()
+    w = AudioWobbler(clock=clock)
+    stop = threading.Event()
+
+    def _feeder() -> None:
+        chunk = _loud_chunk()
+        while not stop.is_set():
+            w.feed(chunk)
+
+    t = threading.Thread(target=_feeder)
+    t.start()
+    try:
+        for _ in range(500):
+            clock.advance(0.001)
+            w.current_offset()
+    finally:
+        stop.set()
+        t.join(timeout=1.0)

--- a/tests/test_robot_kids_teacher.py
+++ b/tests/test_robot_kids_teacher.py
@@ -72,3 +72,108 @@ def test_missing_reachy_mini_returns_exit_code_two(monkeypatch):
 
     exit_code = robot_kids_teacher.main(["--session-id", "test-session"])
     assert exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Motion-director CLI flag + factory + gaze loop subscriber swap
+# ---------------------------------------------------------------------------
+
+
+def test_motion_layers_cli_flag_is_parsed():
+    import robot_kids_teacher
+
+    parser = robot_kids_teacher._build_parser()
+    parsed = parser.parse_args(["--motion-layers", "wobble,tracking"])
+    assert parsed.motion_layers == "wobble,tracking"
+
+
+def test_motion_layers_cli_default_is_none():
+    import robot_kids_teacher
+
+    parser = robot_kids_teacher._build_parser()
+    parsed = parser.parse_args([])
+    assert parsed.motion_layers is None
+
+
+def test_resolve_motion_layers_spec_prefers_cli_over_env(monkeypatch):
+    import robot_kids_teacher
+
+    monkeypatch.setenv(robot_kids_teacher._MOTION_LAYERS_ENV_VAR, "tracking")
+    spec = robot_kids_teacher._resolve_motion_layers_spec("wobble")
+    assert spec == "wobble"
+
+
+def test_resolve_motion_layers_spec_falls_back_to_env(monkeypatch):
+    import robot_kids_teacher
+
+    monkeypatch.setenv(robot_kids_teacher._MOTION_LAYERS_ENV_VAR, "tracking")
+    assert robot_kids_teacher._resolve_motion_layers_spec(None) == "tracking"
+    assert robot_kids_teacher._resolve_motion_layers_spec("") == "tracking"
+
+
+def test_resolve_motion_layers_spec_returns_none_when_unset(monkeypatch):
+    import robot_kids_teacher
+
+    monkeypatch.delenv(robot_kids_teacher._MOTION_LAYERS_ENV_VAR, raising=False)
+    assert robot_kids_teacher._resolve_motion_layers_spec(None) is None
+
+
+def test_maybe_make_motion_stack_returns_none_when_layers_none():
+    import robot_kids_teacher
+
+    class _Robot:
+        pass
+
+    stack = robot_kids_teacher._maybe_make_motion_stack(
+        _Robot(), layers_spec="none", audio_sample_rate=24000
+    )
+    assert stack is None
+
+
+def test_maybe_make_motion_stack_returns_stack_when_layers_full():
+    import robot_kids_teacher
+
+    class _Robot:
+        def apply_pose(self, **_kwargs):
+            return True
+
+    stack = robot_kids_teacher._maybe_make_motion_stack(
+        _Robot(), layers_spec="full", audio_sample_rate=24000
+    )
+    assert stack is not None
+    # The full stack exposes the gesture tool surface.
+    names = {t["name"] for t in stack.additional_tool_specs()}
+    assert "play_gesture" in names
+
+
+def test_make_gaze_loop_factory_attaches_motion_stack_when_provided():
+    """When a motion stack is passed, the gaze loop must wire its face
+    mixer to the FaceTracker — not the debug-log subscriber."""
+    import robot_kids_teacher
+
+    attached = []
+
+    class _StackStub:
+        def attach_face_tracker(self, tracker):
+            attached.append(tracker)
+
+        def detach_face_tracker(self):
+            attached.append("detached")
+
+    factory = robot_kids_teacher._make_gaze_loop_factory(
+        camera_worker=object(), motion_stack=_StackStub()
+    )
+    # We're not running the loop end-to-end here; just confirm the factory
+    # returns a coroutine factory and that the integration path is wired.
+    assert callable(factory)
+
+
+def test_make_gaze_loop_factory_falls_back_to_debug_subscriber_without_stack():
+    """No motion stack → no attach_face_tracker call; debug subscriber
+    is the only consumer."""
+    import robot_kids_teacher
+
+    factory = robot_kids_teacher._make_gaze_loop_factory(
+        camera_worker=object(), motion_stack=None
+    )
+    assert callable(factory)

--- a/tests/test_robot_teacher.py
+++ b/tests/test_robot_teacher.py
@@ -495,3 +495,60 @@ def test_run_lesson_session_keeps_looping_while_play_again_is_yes(monkeypatch):
     )
 
     assert len(lesson_calls) == 1 + REPLAY_WORD_BATCH + REPLAY_WORD_BATCH
+
+
+# ---------------------------------------------------------------------------
+# apply_pose — streaming sink for the motion-director composer
+# ---------------------------------------------------------------------------
+
+
+def test_apply_pose_translates_offsets_to_goto_target_call():
+    mini = _FakeMini()
+    controller = RobotController(mini)
+    ok = controller.apply_pose(
+        head_pitch=0.1,
+        head_yaw=-0.05,
+        head_roll=0.02,
+        head_x=0.001,
+        head_y=-0.002,
+        head_z=0.003,
+        antenna_left=0.4,
+        antenna_right=-0.4,
+        duration=0.033,
+    )
+    assert ok is True
+    assert len(mini.goto_calls) == 1
+    call = mini.goto_calls[0]
+    assert call["duration"] == 0.033
+    assert call["method"] == "minjerk"
+    # Antennae shape: [left, right]
+    assert list(call["antennas"]) == [0.4, -0.4]
+
+
+def test_apply_pose_drops_frame_when_lock_contended():
+    mini = _FakeMini()
+    controller = RobotController(mini)
+    # Hold the motion lock so the apply_pose acquire times out.
+    controller._motion_lock.acquire()
+    try:
+        ok = controller.apply_pose(duration=0.01)
+    finally:
+        controller._motion_lock.release()
+    assert ok is False
+    assert mini.goto_calls == []
+
+
+def test_apply_pose_swallows_sdk_errors():
+    mini = _FakeMini()
+
+    def _raise(**_kwargs):
+        raise RuntimeError("motor offline")
+
+    mini.goto_behavior = _raise
+    controller = RobotController(mini)
+    ok = controller.apply_pose(head_pitch=0.1, duration=0.033)
+    assert ok is False
+    # Subsequent frames should still attempt the call.
+    mini.goto_behavior = None
+    ok2 = controller.apply_pose(head_pitch=0.1, duration=0.033)
+    assert ok2 is True


### PR DESCRIPTION
## Summary
Implements Phases 0–3 of `tasks/plan-motion-director.md`: motion composer, face-offset mixer (L3), audio wobbler (L1), gesture library + scheduler + LLM tool calls (L2), and bridge wiring. Adds env-var kill-switches (`KIDS_TEACHER_MOTION_LAYERS`).

Closes the gap that makes face tracking non-functional on `main` today: the `FaceTracker` producer publishes targets, but the only subscriber is a debug logger. This branch adds the `FaceOffsetMixer` consumer and threads the offset through the composer to motors.

**Scope:** +5021 lines / 32 files. New `src/motion/` package: composer, face_offset, library, scheduler, stack, wobbler, tool_specs, types. Touches `kids_teacher_robot_bridge.py`, `kids_teacher_realtime.py`, `robot_kids_teacher.py`, `robot_teacher.py`. Includes ~10 new test files.

## Review status
Awaiting `/ultrareview` before merge. No major issues = merge.

## Test plan
- [ ] `/ultrareview <this PR#>` clean
- [ ] `pytest` passes locally
- [ ] On-robot smoke: head visibly tracks face during a kids-teacher session; idle/speak/listen still behave correctly when no face is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)